### PR TITLE
(maint) move dev deps to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,21 @@
 source 'https://rubygems.org'
 
+# place all development, system_test, etc dependencies here
+
 group :system_tests do
   #gem 'beaker', :path => "../../beaker/"
-  gem 'beaker', '~> 2.22.0'
+  gem 'beaker'               ,'~> 2.22'
   gem 'beaker-hostgenerator'
+end
+
+group :development do
+  gem 'rspec'                ,'~> 3.1.0'
+  gem 'simplecov'
+  #Documentation dependencies
+  gem 'yard'                 ,'~> 0'
+  gem 'markdown'             ,'~> 0'
+  # restrict version to enable ruby 1.9.3
+  gem 'mime-types'           ,'~> 2.0'
 end
 
 local_gemfile = "#{__FILE__}.local"

--- a/rototiller.gemspec
+++ b/rototiller.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# place ONLY runtime dependencies in here (in addition to metadata)
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rototiller/version'
@@ -13,14 +14,6 @@ Gem::Specification.new do |s|
   s.version       = Rototiller::Version::STRING
   s.license       = 'Apache-2.0'
   s.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
-
-  #Development dependencies
-  s.add_development_dependency 'rspec', '~> 3.1.0'
-  s.add_development_dependency 'simplecov'
-
-  #Documentation dependencies
-  s.add_development_dependency 'yard', '~> 0'
-  s.add_development_dependency 'markdown', '~> 0'
 
   #Run time dependencies
   s.add_runtime_dependency 'rake'


### PR DESCRIPTION
This change reduces the overhead in runtime dependencies for Rototiller.
It also allows us to only specify system_test and development deps in a
single (Gem)file.

fyi, @zreichert 
