### PR TITLE
(QA-2435) 'last comment' throws a deprecation warning in rake

### DIFF
--- a/lib/rototiller/rake/dsl/dsl_extention.rb
+++ b/lib/rototiller/rake/dsl/dsl_extention.rb
@@ -6,7 +6,7 @@ module Rake
     def acceptance_task(*args, &block)
       # Default task description
       # can be overridden with 'desc' method
-      desc "Tests in the 'Acceptance' tier" unless ::Rake.application.last_comment
+      desc "Tests in the 'Acceptance' tier" unless ::Rake.application.last_description
       Rototiller::Task::RototillerTask.define_task :acceptance, &block
     end
 

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -78,7 +78,7 @@ module Rototiller
       def define(args, &task_block)
         # Default task description
         # can be overridden with standard 'desc' DSL method
-        desc 'RototillerTask: A Task with optional environment variable and command flag tracking' unless ::Rake.application.last_comment
+        desc 'RototillerTask: A Task with optional environment-variable and command-flag tracking' unless ::Rake.application.last_description
 
         task(@name, *args) do |_, task_args|
           RakeFileUtils.__send__(:verbose, @verbose) do

--- a/rototiller.gemspec
+++ b/rototiller.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
 
   #Run time dependencies
-  s.add_runtime_dependency 'rake'
+  s.add_runtime_dependency 'rake', '>= 0.9.0'
 end

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -38,9 +38,12 @@ module Rototiller::Task
           expect(Rake.application.invoke_task("task_name")).to be_an(Array)
           # this will fail if previous tests don't adequately clear the desc stack
           # http://apidock.com/ruby/v1_9_3_392/Rake/TaskManager/get_description
-          expect(Rake.application.last_comment).to eq 'RototillerTask: A Task with optional environment variable and command flag tracking'
+          expect(Rake.application.last_description).to eq 'RototillerTask: A Task with optional environment-variable and command-flag tracking'
         end
         #TODO override comment
+        it "doesn't say last_comment is deprecated '#{init_method}'" do
+          expect { described_run_task }.not_to output(/\[DEPRECATION\] `last_comment`/).to_stdout
+        end
       end
 
       context "with args passed to the '#{init_method}' rake task" do


### PR DESCRIPTION
last_comment was deprecated in rake 11+.  use last_description
last_description was around at least back as far as rake 0.9.0, and we
have other issues with rake 0.8.x
note rake versions go from 0.9.x to 10.x
