### PR TITLE
(QA-2457) override_env for command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,9 +64,9 @@ rototiller_task :acceptance => [:generate_host_config] do |t|
     flag.override_env = 'BEAKER_TESTS'
   end
 
-  t.command = 'beaker --debug'
+  t.add_command({:name => 'beaker --debug', :override_env => 'BEAKER_EXECUTABLE'})
 end
 
 Rototiller::Task::RototillerTask.define_task :check_test do |t|
-  t.add_env(:name => 'SPEC_PATTERN', :default => 'spec/', :message => 'The pattern RSpec will use to find tests')
+  t.add_env({:name => 'SPEC_PATTERN', :default => 'spec/', :message => 'The pattern RSpec will use to find tests'})
 end

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -46,7 +46,7 @@ require 'rototiller'
 
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
-    t.command = 'echo'
+    t.add_command({:name => 'echo'})
 end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)

--- a/acceptance/tests/rototillerTask/dependent_tasks.rb
+++ b/acceptance/tests/rototillerTask/dependent_tasks.rb
@@ -10,20 +10,20 @@ test_name 'C97794: ensure RototillerTasks can be parent/child tasks' do
   $LOAD_PATH.unshift('/root/rototiller/lib')
   require 'rototiller'
 
-  task :child do |t|
-    system('echo "i am the native child"')
-  end
-  task :parent => [:r_child, :child] do |t|
-    system('echo "i am the native parent"')
-  end
-  #{new_task_method} :r_child do |t|
-    t.command = 'echo "i am the tiller child"'
-  end
-  #{new_task_method} :r_parent => [:r_child, :child] do |t|
-    t.command = 'echo "i am the tiller parent"'
-  end
-    EOS
-    rakefile_path = create_rakefile_on(sut, rakefile_contents)
+task :child do |t|
+  system('echo "i am the native child"')
+end
+task :parent => [:r_child, :child] do |t|
+  system('echo "i am the native parent"')
+end
+Rototiller::Task::RototillerTask.define_task :r_child do |t|
+  t.add_command({:name => 'echo "i am the tiller child"'})
+end
+Rototiller::Task::RototillerTask.define_task :r_parent => [:r_child, :child] do |t|
+  t.add_command({:name => 'echo "i am the tiller parent"'})
+end
+  EOS
+  rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     step "Execute task defined in rake task 'r_parent'" do
       on(sut, "rake r_parent", :accept_all_exit_codes => true) do |result|

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -49,7 +49,7 @@ require 'rototiller'
 
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
-    t.command = 'echo'
+    t.add_command({:name => 'echo'})
 end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
@@ -86,7 +86,7 @@ require 'rototiller'
 
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
-    t.command = 'echo'
+    t.add_command({:name => 'echo'})
 end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
@@ -106,4 +106,3 @@ end
     end
   end
 end
-

--- a/acceptance/tests/rototillerTask/override_command_with_env.rb
+++ b/acceptance/tests/rototillerTask/override_command_with_env.rb
@@ -1,0 +1,69 @@
+require 'beaker/hosts'
+require 'rakefile_tools'
+
+test_name 'C97827: can set envvar to override command name when using task.command' do
+  extend Beaker::Hosts
+  extend RakefileTools
+
+  step 'Test command with an override_env that has a value' do
+
+    override_env = 'BROCKSAMSON'
+    env_key = 'THIS_WAS_IN_ENV'
+    env_value = 'echo ' << env_key
+
+    @task_name    = 'command_flags_with_override'
+    rakefile_contents = <<-EOS
+$LOAD_PATH.unshift('/root/rototiller/lib')
+require 'rototiller'
+
+Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
+    t.add_command({:name => 'echo', :override_env => '#{override_env}'})
+end
+    EOS
+    rakefile_path = create_rakefile_on(sut, rakefile_contents)
+    sut.add_env_var(override_env, env_value)
+
+    step 'Execute task defined in rake task' do
+      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
+        # exit code & no error in output
+        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
+        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+
+        # command was used that was supplied by the override_env
+        assert_match(/^#{env_key}/, result.stdout, 'The correct command was not observed')
+      end
+    end
+  end
+
+  step 'Add Command with block syntax and unset override_env' do
+
+    override_env = 'EMPTYENV'
+
+    @task_name    = 'command_flags_with_override'
+
+    validation_string = (0...10).map { ('a'..'z').to_a[rand(26)] }.join
+
+    rakefile_contents = <<-EOS
+$LOAD_PATH.unshift('/root/rototiller/lib')
+require 'rototiller'
+
+Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
+    t.add_command do |c|
+      c.name = 'echo #{validation_string}'
+      c.override_env = '#{override_env}'
+    end
+end
+    EOS
+    rakefile_path = create_rakefile_on(sut, rakefile_contents)
+
+    step 'Execute task defined in rake task' do
+      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
+
+        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
+        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+
+        assert_match(/#{validation_string}/, result.stdout, 'The correct command was not observed')
+      end
+    end
+  end
+end

--- a/acceptance/tests/rototillerTask/task_with_args.rb
+++ b/acceptance/tests/rototillerTask/task_with_args.rb
@@ -12,9 +12,9 @@ require 'rototiller'
 
 rototiller_task :#{rake_task_name}, [:arg1, :arg2] do |t, args|
   if args[:arg2]
-    t.command = "echo 'task args: #\{args\}'"
+    t.add_command({:name => "echo 'task args: #\{args\}'"})
   else
-    t.command = "echo 'task arg1: #\{args[:arg1]\}'"
+    t.add_command({:name => "echo 'task arg1: #\{args[:arg1]\}'"})
   end
 end
   EOS

--- a/lib/rototiller/utilities/block_syntax_object.rb
+++ b/lib/rototiller/utilities/block_syntax_object.rb
@@ -1,0 +1,16 @@
+module Rototiller
+  class Block_syntax
+
+    def initialize(param_array)
+      self.class.class_eval { param_array.each { |i| attr_accessor i } }
+    end
+
+    def to_h
+      h = Hash.new
+      self.instance_variables.each do |var|
+        h[var.to_s.delete('@').to_sym] = self.instance_variable_get(var)
+      end
+      h
+    end
+  end
+end

--- a/lib/rototiller/utilities/command.rb
+++ b/lib/rototiller/utilities/command.rb
@@ -1,0 +1,28 @@
+require 'rototiller/utilities/env_var'
+module Rototiller
+  class Command
+
+    include ColorText
+
+    # @return [String] the command to be used, could be considered a default
+    attr_reader :name
+
+    # @return [EnvVar] the ENV that is equal to this command
+    attr_reader :override_env
+
+    # Creates a new instance of CommandFlag, holds information about desired state of a command
+    # @param [Hash] attribute_hash hashes of information about the command
+    # @option attribute_hash [String] :command The command
+    # @option attribute_hash [String] :override_env The environment variable that can override this command
+    def initialize(attribute_hash)
+      # translate the keys from 'Command' to Env
+      if attribute_hash[:override_env]
+        @override_env = EnvVar.new({:name => attribute_hash [:override_env], :default => attribute_hash[:name]})
+        @name = @override_env.value
+      else
+        @name = attribute_hash[:name]
+      end
+    end
+  end
+end
+

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -70,12 +70,12 @@ module Rototiller::Task
         end
 
         it 'prints it if the command run failed' do
-          task.command = 'exit 1'
+          task.add_command({:name => 'exit 1'})
           expect { described_run_task }.to output(/Bad news/).to_stdout
         end
 
         it 'does not print it if the command run succeeded' do
-          task.command = 'echo'
+          task.add_command({:name =>  'echo'})
           expect { described_run_task }.not_to output(/Bad/).to_stdout
         end
       end
@@ -83,7 +83,7 @@ module Rototiller::Task
       context 'with custom exit status' do
         it 'returns the correct status on exit', :slow do
           expect(task).to receive(:exit).with(2)
-          task.command = 'ruby -e "exit(2);" ;#'
+          task.add_command({:name => 'ruby -e "exit(2);" ;#'})
           described_run_task
         end
       end
@@ -105,7 +105,7 @@ module Rototiller::Task
           #  so any of these that run system spews that to the output.  We should probably not set that as the default command.  it's a bit verbose and pedantic.
           #  it doesn't check if there are any envs or other tasks, and there are good reasons to not have a command, in some cases
           silence_output do
-            task.command = 'exit 2'
+            task.add_command({:name => 'exit 2'})
             described_verbose(true)
             expect { described_run_task }.to output(/failed/).to_stderr
             described_verbose(false)
@@ -114,7 +114,7 @@ module Rototiller::Task
         it 'doesn\'t print if fail_on_error is false' do
           expect(task).to_not receive(:exit)
           task.fail_on_error = false
-          task.command = 'exit 2'
+          task.add_command({:name =>  'exit 2'})
           expect { described_run_task }.to output("").to_stderr
         end
       end
@@ -126,7 +126,7 @@ module Rototiller::Task
         let(:value) {'I am a value'}
         it "renders cli for '#{init_method}' with one flag" do
           arg = {:name => flag1, :message => 'description', :default => value}
-          task.command = command
+          task.add_command({:name => command})
           task.add_flag(arg)
           expect(task).to receive(:system).with("#{command} #{flag1} #{value}").and_return(true)
           silence_output do
@@ -134,7 +134,7 @@ module Rototiller::Task
           end
         end
         it "renders cli for '#{init_method}' with multiple flags" do
-          task.command = command
+          task.add_command({:name => command})
           task.add_flag({:name => flag1, :message => 'other description', :default => value})
           task.add_flag({:name => '-t', :message => '-t description', :default => 'tvalue'})
           expect(task).to receive(:system).with("#{command} #{flag1} #{value} -t tvalue").and_return(true)


### PR DESCRIPTION
We need to decide how we want to collect information about the command to be executed. 

```
t.add_command( {:command => 'echo', :override_env => 'ECHO_OVERRIDE'})
```

Would :name be better than :command ? 
Do we still want to support 

```
t.command = 'echo'
```
