### PR TITLE
Add ability to ignore a command flag if default is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ Rototiller provides a Rake DSL addition called 'rototiller_task' which is a full
       end
     end
 
+    desc "do not include flag if the final value (either the default or override_env) is nil or empty and not required"
+    rototiller_task :test_flag_env do |task|
+      task.add_command do |cmd|
+        cmd.name = 'test'
+      end
+      task.add_flag do |flag|
+        flag.name         = '-f'
+        flag.default      = ''
+        flag.override_env = 'FLAG_VALUE'
+        flag.required     = false
+      end
+    end
+
     desc "override command argument values with environment variables"
     rototiller_task :test_arg_env do |task|
       task.add_command do |cmd|

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -46,12 +46,13 @@ module Rototiller
       # @option args [String] :name The environment variable
       # @option args [String] :default The default value for the environment variable
       # @option args [String] :message A message describing the use of this variable
+      # @option args [Boolean] :required Is used internally by CommandFlag, ignored for a standalone EnvVar
       #
       # for block {|a| ... }
       # @yield [a] Optional block syntax allows you to specify information about the environment variable, available methods track hash keys
       def add_env(*args,&block)
         raise ArgumentError.new("add_env takes a block or a hash") if !args.empty? && block_given?
-        attributes = [:name, :default, :message]
+        attributes = [:name, :default, :message, :required]
         add_param(@env_vars, EnvVar, attributes, args, {:set_env => true}, &block)
       end
 
@@ -61,17 +62,19 @@ module Rototiller
       # @option args [String] :value The value for the command line flag
       # @option args [String] :message A message describing the use of this command line flag
       # @option args [String] :override_env An environment variable used to override the flag value
+      # @option args [Boolean] :required Indicates whether an error should be raised
+      # if the value is nil or empty string, vs not including the flag.
       #
       # for block {|a| ... }
       # @yield [a] Optional block syntax allows you to specify information about the command line flag, available methods track hash keys
       def add_flag(*args, &block)
         raise ArgumentError.new("add_flag takes a block or a hash") if !args.empty? && block_given?
-        attributes = [:name, :default, :message, :override_env]
+        attributes = [:name, :default, :message, :override_env, :required]
         add_param(@flags, CommandFlag, attributes, args, &block)
       end
 
       # adds command to be executed by task
-      # @param [Hash] args hash of information about the command to be exedcuted
+      # @param [Hash] args hash of information about the command to be executed
       # @option arg [String] :name The command to be executed
       # @option arg [String] :override_env An environment variable used to override the command to be executed by the task
       #

--- a/lib/rototiller/utilities/flag_collection.rb
+++ b/lib/rototiller/utilities/flag_collection.rb
@@ -14,7 +14,9 @@ class FlagCollection < ParamCollection
     flag_str = String.new
 
     @collection.each do |flag|
-      if flag.value.nil?
+      if (flag.value.nil? || flag.value.empty?) && !flag.required
+        #do nothing
+      elsif flag.value.nil?
         flag_str << flag.flag << ' '
       else
         flag_str << flag.flag << ' ' << flag.value << ' '

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -219,6 +219,7 @@ module Rototiller::Task
         let(:argument) {random_string}
         let(:command_env) {unique_env}
         let(:argument_env) {unique_env}
+        let(:flag_override_env) {unique_env}
         let(:add_flag_args) { {:name => '--flag', :default => 'flag_value'} }
         let(:args) { {:name => echo_command, :argument => argument, :override_env => command_env, :argument_override_env => argument_env} }
         context 'variables not set' do
@@ -241,12 +242,29 @@ module Rototiller::Task
             ENV[command_env] = "echo #{command_env_value}"
             ENV[argument_env] = argument_env_value
 
+
             task.add_command(args)
             task.add_flag(add_flag_args)
             task.send(:set_verbose)
 
             expect { described_run_task }
             .to output(/#{command_env_value} #{add_flag_args[:name]} #{add_flag_args[:default]} #{argument_env_value}/)
+            .to_stdout
+          end
+        end
+        context 'flag with no value, required=false' do
+          it 'should not include the non required flag with no value' do
+            flag_override_env_value = ''
+            ENV[flag_override_env] = flag_override_env_value
+
+            task.add_command(args)
+            add_flag_args[:required] = false
+            add_flag_args[:override_env] = flag_override_env
+            task.add_flag(add_flag_args)
+            task.send(:set_verbose)
+
+            expect { described_run_task }
+            .to output(/#{command} #{argument}/)
             .to_stdout
           end
         end

--- a/spec/rototiller/utilities/command_flag_spec.rb
+++ b/spec/rototiller/utilities/command_flag_spec.rb
@@ -76,5 +76,38 @@ describe CommandFlag do
         expect(subject.message).to match(expected_message)
       end
     end
+
+    context 'not required, no value provided' do
+      override_env_val = random_string
+      let(:args) { {:name => flag, :override_env => override_env_val, :message => message, :required => false} }
+
+      it 'should report that the flag will not be used' do
+        expected_message = /The CLI flag #{flag} has no value assigned and will not be included./
+        expect(subject.message).to match(expected_message)
+      end
+    end
+
+    context 'not required, value provided, override value to nothing' do
+      override_env_val = random_string
+      let(:args) { {:name => flag, :override_env => override_env_val, :default => 'foo', :message => message, :required => false} }
+      ENV[override_env_val] = ''
+
+      it 'should report that the flag will not be used' do
+        expected_message = /The CLI flag #{flag} has no value assigned and will not be included./
+        expect(subject.message).to match(expected_message)
+      end
+    end
+
+    context 'not required, value provided, override value' do
+      override_env_val = random_string
+      value = random_string
+      let(:args) { {:name => flag, :override_env => override_env_val, :default => 'foo', :message => message, :required => false} }
+      ENV[override_env_val] = value
+
+      it 'should report that the flag will not be used' do
+        expected_message = /The CLI flag #{flag} will be used with value #{value}./
+        expect(subject.message).to match(expected_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
I've got the optional param: 
  t.add_flag do |flag|
    flag.name = '--load-path'
    flag.default = nil
    flag.message = 'Additional load path for Beaker'
    flag.override_env = 'BEAKER_LOAD_PATH'
  end

And I wanted to be able to have it not included at all if the default was nil.  Maybe there's a better way to indicate that it is optional?  Would we prefer an additional 'optional' param for flag?
