### PR TITLE
(QA-2489) acceptance should build and install gem

### DIFF
--- a/acceptance/pre-suite/01_install_rototiller.rb
+++ b/acceptance/pre-suite/01_install_rototiller.rb
@@ -1,7 +1,13 @@
+require 'rototiller/version'
+
+gem_name = "rototiller-#{Rototiller::Version::STRING}.gem"
+teardown do
+  `rm #{gem_name}`
+end
+
 sut = find_only_one('agent')
 
-# copy dir to SUT
-source_path = File.expand_path('./')
-excludes = ['.bundle', '.rubocop.yml', '.git', 'coverage', '.gitignore',
-                  'Gemfile.lock', 'junit', 'log']
-scp_to(sut, source_path, '/root', {:ignore => excludes})
+`gem build rototiller.gemspec`
+scp_to(sut, gem_name, '/root')
+
+on(sut, "gem install #{gem_name}")


### PR DESCRIPTION
Jenkins acceptance is failing to properly install rototiller from
source. We should be doing it from a gem anyway.  This change builds the
gem locally and installs it on the sut.

[skip-ci]
