### PR TITLE
(QA-2445) Add support for setting boolean flags with rototiller

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Rototiller provides a Rake DSL addition called 'rototiller_task' which is a full
       end
     end
 
-    desc "do not include flag if the final value (either the default or override_env) is nil or empty and not required"
+    desc "do not include flag if the final value (either the default or override_env) is nil or empty and not required. add and control switches or boolean flags"
     rototiller_task :test_flag_env do |task|
       task.add_command do |cmd|
         cmd.name = 'test'
@@ -59,7 +59,15 @@ Rototiller provides a Rake DSL addition called 'rototiller_task' which is a full
         flag.override_env = 'FLAG_VALUE'
         flag.required     = false
       end
+      # examples:
+      # add a boolean option (switch)
+      #task.add_flag({:name => '--switch1', :is_boolean => true})
+      # add a switch which defaults to "off"
+      #task.add_flag({:name => '-s',  :default => '', :is_boolean => true})
+      # add a switch with environment override
+      #task.add_flag({:name => '--switch3', :is_boolean => true, :override_env => 'TEST_FLAG_ENV_SWITCH3'})
     end
+
 
     desc "override command argument values with environment variables"
     rototiller_task :test_arg_env do |task|

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -59,7 +59,7 @@ end
 
       command_flags.each do |flag|
         command_regex = /#{flag[:name]} #{flag[:default]}/
-        rototiller_output_regex = /The CLI flag #{flag[:name]} will be used with value #{flag[:default]}/
+        rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{flag[:default]}'/
         assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
         assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
       end

--- a/acceptance/tests/rototillerTask/command_switches.rb
+++ b/acceptance/tests/rototillerTask/command_switches.rb
@@ -1,0 +1,94 @@
+require 'beaker/hosts'
+require 'rakefile_tools'
+
+test_name 'C97821: can set switches (boolean options) for commands in a RototillerTask' do
+  extend Beaker::Hosts
+  extend RakefileTools
+
+  test_filename = File.basename(__FILE__, '.*')
+
+  def create_rakefile_task_segment(flags)
+    segment = ''
+    flags.each.with_index do |flag,index|
+      sut.add_env_var(flag[:override_env], flag[:env_value]) if flag[:override_env]
+      if flag[:block_syntax]
+        segment += "t.add_flag do |flag|\n"
+        remove_reserved_keys(flag).each do |k, v|
+          segment += "  flag.#{k.to_s} = '#{v}'\n"
+        end
+        segment += "end\n"
+      else
+        segment += "  t.add_flag({"
+        remove_reserved_keys(flag).each do |k, v|
+          segment += ":#{k} => '#{v}',"
+        end
+        segment += "})\n"
+      end
+    end
+    return segment
+  end
+
+  def remove_reserved_keys(h)
+    hash = h.dup
+    [:block_syntax, :env_value].each do |key|
+      hash.delete(key)
+    end
+    return hash
+  end
+
+  command_flags = [
+      {:name => '--name1',                  :is_boolean => true},
+      {:name => '--name2',  :default => '', :is_boolean => true},
+      {:name => '--name3',                  :is_boolean => true, :override_env => 'NODEFAULT1',  :env_value => 'VAL1'},
+      {:name => '--name4',  :default => '', :is_boolean => true, :override_env => 'HASDEFAULT1', :env_value => 'VAL2'},
+      {:name => '--name5',                  :is_boolean => true, :override_env => 'NODEFAULT2',  :env_value => ''},
+      {:name => '--name6',  :default => '', :is_boolean => true, :override_env => 'HASDEFAULT2', :env_value => ''},
+      {:name => '--name7',                  :is_boolean => true,                                                        :block_syntax => true},
+      {:name => '--name8',  :default => '', :is_boolean => true,                                                        :block_syntax => true},
+      {:name => '--name9',                  :is_boolean => true, :override_env => 'NODEFAULT3',  :env_value => 'VAL3',  :block_syntax => true},
+      {:name => '--nameA',  :default => '', :is_boolean => true, :override_env => 'HASDEFAULT3', :env_value => 'VAL4',  :block_syntax => true},
+      {:name => '--nameB',                  :is_boolean => true, :override_env => 'NODEFAULT4',  :env_value => '',      :block_syntax => true},
+      {:name => '--nameC',  :default => '', :is_boolean => true, :override_env => 'HASDEFAULT4', :env_value => '',      :block_syntax => true},
+  ]
+
+
+  @task_name    = test_filename
+  rakefile_contents = <<-EOS
+$LOAD_PATH.unshift('/root/rototiller/lib')
+require 'rototiller'
+
+Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
+    #{create_rakefile_task_segment(command_flags)}
+    t.add_command({:name => 'echo'})
+end
+  EOS
+  rakefile_path = create_rakefile_on(sut, rakefile_contents)
+
+  step 'Execute task defined in rake task' do
+    on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
+      # exit code & no error in output
+      assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
+      assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+
+      # i plainly refuse to re-implement rototiller's is_boolean option logic here
+      expected_out = <<-HERE
+\e[32mThe CLI switch '--name1' will be used.\e[0m
+\e[33mThe CLI switch '--name2' will NOT be used.\e[0m
+\e[32mThe CLI switch 'VAL1' will be used.\e[0m
+\e[32mThe CLI switch 'VAL2' will be used.\e[0m
+\e[33mThe CLI switch '--name5' will NOT be used.\e[0m
+\e[33mThe CLI switch '--name6' will NOT be used.\e[0m
+\e[32mThe CLI switch '--name7' will be used.\e[0m
+\e[33mThe CLI switch '--name8' will NOT be used.\e[0m
+\e[32mThe CLI switch 'VAL3' will be used.\e[0m
+\e[32mThe CLI switch 'VAL4' will be used.\e[0m
+\e[33mThe CLI switch '--nameB' will NOT be used.\e[0m
+\e[33mThe CLI switch '--nameC' will NOT be used.\e[0m
+
+--name1 VAL1 VAL2 --name7 VAL3 VAL4
+HERE
+      assert_equal(expected_out,result.output, 'output did not match')
+
+    end
+  end
+end

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -38,9 +38,10 @@ test_name 'C97798: existing workflows shall be supported for using ENV vars to o
 
   step 'Test flags that will let command continue' do
 
+    test_filename = File.basename(__FILE__, '.*')
     command_flags = [
-        {:name => '--setenv-nodefault', :override_env => 'NODEFAULT', :exists => true},
-        {:name => '--setenv-default', :block_syntax => true, :exists => true, :default => 'Author specified default'},
+      {:name => '--setenv-nodefault', :override_env => "NODEFAULT_#{test_filename.upcase}", :exists => true},
+      {:name => '--setenv-default', :block_syntax => true, :exists => true, :default => 'Author specified default'},
     ]
 
 
@@ -65,7 +66,7 @@ end
         command_flags.each do |flag|
           value = flag[:default] || "#{flag[:override_env]}: env present value"
           command_regex = /#{flag[:name]} #{value}/
-          rototiller_output_regex = /The CLI flag #{flag[:name]} will be used with value #{value}/
+          rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{value}'/
 
           assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
           assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
@@ -101,7 +102,7 @@ end
         assert_no_match(/error/i, result.output, 'An unexpected error was observed')
 
         command_flags.each do |flag|
-          regex = /The CLI flag #{flag[:name]} needs a value.\nYou can specify this value with the environment variable #{flag[:override_env]}/
+          regex = /The CLI flag '#{flag[:name]}' needs a value.\nYou can specify this value with the environment variable '#{flag[:override_env]}'/
           assert_match(regex, result.stdout, "The expected output from rototiller was not observed")
         end
       end
@@ -131,8 +132,8 @@ end
 
       on(sut, "rake #{@task_name} #{override}=''", :accept_all_exit_codes => true) do |result|
         # exit code & no error in output
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+        assert(result.exit_code == 0, 'The expected exit code 0 was not observed, (non-required flags)')
+        assert_no_match(/error/i, result.output, 'An unexpected error was observed (non-required flags)')
 
         command_flags.each do |flag|
           regex = /The CLI flag #{flag[:name]} has no value assigned and will not be included./

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -150,7 +150,8 @@ module Rototiller
 
           args.each do |arg|
 
-            raise ArgumentError.new("Argument must ba a Hash not a #{arg.class}") unless arg.is_a?(Hash)
+            #FIXME: add a test for this
+            raise ArgumentError.new("Argument must be a Hash. Received: '#{arg.class}'") unless arg.is_a?(Hash)
             arg[:set_env] = true if opts[:set_env]
             collection.push(param_class.new(arg))
           end

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -58,18 +58,19 @@ module Rototiller
 
       # adds command line flags to be used in a command
       # @param [Hash] *args hashes of information about the command line flag
-      # @option args [String] :name The command line flag
-      # @option args [String] :value The value for the command line flag
-      # @option args [String] :message A message describing the use of this command line flag
+      # @option args [String] :name         The command line flag
+      # @option args [String] :value        The value for the command line flag
+      # @option args [String] :message      A message describing the use of this command line flag
       # @option args [String] :override_env An environment variable used to override the flag value
-      # @option args [Boolean] :required Indicates whether an error should be raised
-      # if the value is nil or empty string, vs not including the flag.
+      # @option args [Boolean] :required    Indicates whether an error should be raised
+      #                                     if the value is nil or empty string, vs not including the flag.
+      # @option args [Boolean] :is_boolean  Is the flag really a switch? Is it a boolean-flag?
       #
       # for block {|a| ... }
       # @yield [a] Optional block syntax allows you to specify information about the command line flag, available methods track hash keys
       def add_flag(*args, &block)
         raise ArgumentError.new("add_flag takes a block or a hash") if !args.empty? && block_given?
-        attributes = [:name, :default, :message, :override_env, :required]
+        attributes = [:name, :default, :message, :override_env, :required, :is_boolean]
         add_param(@flags, CommandFlag, attributes, args, &block)
       end
 

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -42,7 +42,7 @@ module Rototiller
       end
 
       # adds environment variables to be tracked
-      # @param [Hash] *args hashes of information about the environment variable
+      # @param [Hash] args hashes of information about the environment variable
       # @option args [String] :name The environment variable
       # @option args [String] :default The default value for the environment variable
       # @option args [String] :message A message describing the use of this variable
@@ -57,7 +57,7 @@ module Rototiller
       end
 
       # adds command line flags to be used in a command
-      # @param [Hash] *args hashes of information about the command line flag
+      # @param       [Hash]   args          hashes of information about the command line flag
       # @option args [String] :name         The command line flag
       # @option args [String] :value        The value for the command line flag
       # @option args [String] :message      A message describing the use of this command line flag
@@ -93,6 +93,7 @@ module Rototiller
 
       private
 
+      # @private
       def print_messages
         puts @flags.format_messages
         puts @env_vars.format_messages
@@ -139,6 +140,7 @@ module Rototiller
         @verbose = verbosity
       end
 
+      # @private
       def add_param(collection, param_class, param_array, args, opts={}, &block)
 
         if block_given?
@@ -158,6 +160,7 @@ module Rototiller
         end
       end
 
+      # @private
       def pull_params_from_block(param_array, &block)
 
         block_syntax_obj = Rototiller::Block_syntax.new(param_array)

--- a/lib/rototiller/utilities/command.rb
+++ b/lib/rototiller/utilities/command.rb
@@ -20,22 +20,22 @@ module Rototiller
     # @param [Hash] attribute_hash hashes of information about the command
     # @option attribute_hash [String] :command The command
     # @option attribute_hash [String] :override_env The environment variable that can override this command
-    def initialize(h = {})
+    def initialize(attribute_hash = {})
 
       # check if an override_env is provided
-      if h[:override_env]
-        @override_env = EnvVar.new({:name => h[:override_env], :default => h[:name]})
+      if attribute_hash[:override_env]
+        @override_env = EnvVar.new({:name => attribute_hash[:override_env], :default => attribute_hash[:name]})
         @name = @override_env.value
       else
-        @name = h[:name]
+        @name = attribute_hash[:name]
       end
 
       # check if an argument_override_env is provided
-      if h[:argument_override_env]
-        @argument_override_env = EnvVar.new({:name => h[:argument_override_env], :default => h[:argument]})
+      if attribute_hash[:argument_override_env]
+        @argument_override_env = EnvVar.new({:name => attribute_hash[:argument_override_env], :default => attribute_hash[:argument]})
         @argument = @argument_override_env.value
       else
-        @argument = h[:argument]
+        @argument = attribute_hash[:argument]
       end
     end
   end

--- a/lib/rototiller/utilities/command_flag.rb
+++ b/lib/rototiller/utilities/command_flag.rb
@@ -20,33 +20,64 @@ class CommandFlag
   # @return [true, nil] if the state of the EnvVar requires the task to stop
   attr_reader :stop
 
+  # @return [true, nil] if this flag/option is really a switch (boolean flag)
+  attr_reader :is_boolean
+
   # Creates a new instance of CommandFlag, holds information about desired state of a CLI flag
   # @param [Hash] attribute_hash hashes of information about the command line flag
-  # @option attribute_hash [String] :name The command line flag
-  # @option attribute_hash [String] :value The value for the command line flag
-  # @option attribute_hash [String] :message A message describing the use of this command line flag
+  # @option attribute_hash [String] :name         The command line flag
+  # @option attribute_hash [String] :value        The value for the command line flag
+  # @option attribute_hash [String] :message      A message describing the use of this command line flag
   # @option attribute_hash [String] :override_env The environment variable that can override this flags value
+  # @option attribute_hash [Boolean] :is_boolean Is the flag really a switch? Is it a boolean-flag?
   # @option attribute_hash [Boolean] :required Indicates whether an error should be raised
   # if the final value is nil or empty string, vs not including the flag.
   def initialize(attribute_hash)
     validate_attribute_hash(attribute_hash)
-    @flag = attribute_hash[:name]
-    @message = attribute_hash[:message]
+
+    @original_name = attribute_hash[:name]
+    @message       = attribute_hash[:message]
+    @is_boolean    = attribute_hash[:is_boolean] || false
+
+    # handle :required
     attribute_hash[:required].is_a?(String) ? attribute_hash[:required] = (attribute_hash[:required].downcase == 'true') : attribute_hash[:required]
     @required = ( !!attribute_hash[:required] == attribute_hash[:required] ? attribute_hash[:required] : true)
 
-    if !attribute_hash[:override_env]
-
-      # the default is the implied hard coded value, or nil if not specified
-      @value = attribute_hash[:default]
+    # handle the flag/switch name
+    if attribute_hash[:name] && !attribute_hash[:is_boolean]
+      @flag = attribute_hash[:name]
     else
+      # default takes precedence in case the default state is "off" aka: empty
+      default_value = attribute_hash[:default] || attribute_hash[:name]
 
-      # Create a new EnvVar instance and ask it what the value is
-      @override_env = EnvVar.new({:name => attribute_hash[:override_env], :default => attribute_hash[:default], :required => @required})
+      # FIXME: whoa complexity.  see fixme below
+      #   this looks a lot like below.  we need a method to handle override_env and the logic here for switches vs. options
+      #   but we're just gonna rip all this out when CommandSwitch inherits from future CommandOption
+      if attribute_hash[:override_env]
+        # Create a new EnvVar instance and ask it what the value is
+        @override_env = EnvVar.new({:name => attribute_hash[:override_env], :default => default_value})
+        @flag = @override_env.value
+      else
+        @flag = default_value
+      end
+    end
 
-      @value = @override_env.value
-      @stop = @override_env.stop
+    # FIXME: this is getting complex. we should not be doing all these complex if/then in here
+    #   we should inherit from CommandOption to form CommandSwitch which overrides is_boolean
+    #   make is_boolean protected (private within a module, parent/child, or similar)
+    if @is_boolean
+      @value = ''
+    else
+      if attribute_hash[:default] && !attribute_hash[:override_env]
+        # the default is the implied hard coded value
+        @value = attribute_hash[:default]
+      else
+        # Create a new EnvVar instance and ask it what the value is
+        @override_env = EnvVar.new({:name => attribute_hash[:override_env], :default => attribute_hash[:default], :required => @required})
 
+        @value = @override_env.value
+        @stop = @override_env.stop
+      end
     end
   end
 
@@ -59,13 +90,23 @@ class CommandFlag
   private
   def describe_flag_state
     if @stop
-      required_env = "The CLI flag #{@flag} needs a value.\nYou can specify this value with the environment variable #{override_env.var}."
+      required_env = "The CLI flag '#{@flag}' needs a value.\nYou can specify this value with the environment variable '#{override_env.var}'"
       return red_text(required_env)
     elsif !@required && (@value.nil? || @value.empty?)
       flag_without_value = "The CLI flag #{@flag} has no value assigned and will not be included."
       return yellow_text(flag_without_value)
     else
-      flag_with_value = "The CLI flag #{@flag} will be used with value #{@value}."
+      if @is_boolean
+        has_flag_name = (@flag != '') && (@flag != nil)
+        if has_flag_name
+          flag_with_value = "The CLI switch '#{@flag}' will be used."
+        else
+          flag_with_value = "The CLI switch '#{@original_name}' will NOT be used."
+          return yellow_text(flag_with_value)
+        end
+      else
+        flag_with_value = "The CLI flag '#{@flag}' will be used with value '#{@value}'."
+      end
       return green_text(flag_with_value)
     end
   end
@@ -74,7 +115,8 @@ class CommandFlag
     # validate the contents of the hash
     error = String.new
     error << "A 'name' is required\n" unless h[:name]
-    error << "You must specify a 'default' or an 'override_env'\n" unless h[:default] || h[:override_env]
+    error << "Cannot use 'required' with 'is_boolean'\n" unless !(h[:required] && h[:is_boolean])
+    error << "Must specify a 'default' or an 'override_env' unless 'is_boolean' is true\n" unless h[:default] || h[:override_env] || h[:is_boolean]
 
     raise(ArgumentError, error) unless error.empty?
   end

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -120,10 +120,20 @@ module Rototiller::Task
       end
 
       # TODO: reduce repetition
+      #   actually most of these are covered in command_flag_spec
+      #   this should just test that it accepts the given args?
       context 'with flags' do
         let(:command) {'nonesuch'}
         let(:flag1) {'--flagoner'}
         let(:value) {'I am a value'}
+
+        it 'should work with correct arguments' do
+          args = {:name => flag1, :default => value, :message => 'blah',
+                  :is_boolean => true, :override_env => 'WAT'}
+          expect{ task.add_flag(args) }.not_to raise_error
+        end
+
+
         it "renders cli for '#{init_method}' with one flag" do
           arg = {:name => flag1, :message => 'description', :default => value}
           task.add_command({:name => command})
@@ -152,7 +162,7 @@ module Rototiller::Task
         it "prints messages for '#{init_method}' with single value CLI flag" do
           task.add_flag({:name => '-t', :message =>  '-t description', :default =>  'tvalue2'})
           expect{ described_run_task }
-            .to output(/-t description.*CLI flag -t will be used with value/m)
+            .to output(/-t description.*CLI flag '-t' will be used with value 'tvalue2'/m)
             .to_stdout
         end
         it "raises argument error for too many flag args" do

--- a/spec/rototiller/utilities/command_flag_spec.rb
+++ b/spec/rototiller/utilities/command_flag_spec.rb
@@ -5,13 +5,22 @@ describe CommandFlag do
   let(:flag)    { "--#{random_string}"}
   let(:message) { "This is the message provided by the user #{random_string}"}
   let(:value)   { random_string }
+  let(:is_boolean)   { false }
+  let(:override_env) { random_string.upcase }
 
   context 'initialize' do
 
     subject   { CommandFlag }
 
     it 'should work with correct arguments' do
-      expect{subject.new({:name => flag, :default => value, :message => message})}.not_to raise_error
+      expect{subject.new({:name => flag, :default => value, :message => message, :is_boolean => is_boolean})}.not_to raise_error
+    end
+    it 'should error with required and is_boolean' do
+      expect{subject.new({:name => flag, :default => value, :is_boolean => true, :required => true})}.to raise_error
+    end
+    # FIXME: this is bad.  i should be able to add a flag with just its (i suppose is_boolean)
+    it 'should error without one of default or override_env' do
+      expect{subject.new({:name => flag})}.to raise_error
     end
   end
 
@@ -24,12 +33,20 @@ describe CommandFlag do
       it { is_expected.to respond_to(:value).with(0).arguments }
       it { is_expected.to respond_to(:flag).with(0).arguments }
       it { is_expected.to respond_to(:message).with(0).arguments}
+      it { is_expected.to respond_to(:required).with(0).arguments}
+      it { is_expected.to respond_to(:is_boolean).with(0).arguments}
       it { is_expected.not_to respond_to(:value).with(1).arguments }
       it { is_expected.not_to respond_to(:flag).with(1).arguments }
       it { is_expected.not_to respond_to(:message).with(1).arguments}
+      it { is_expected.not_to respond_to(:required).with(1).arguments}
+      it { is_expected.not_to respond_to(:is_boolean).with(1).arguments}
 
       it 'should report the flag' do
         expect(subject.flag).to eq(flag)
+      end
+
+      it 'should set is_boolean' do
+        expect(subject.is_boolean).to eq(is_boolean)
       end
 
       it 'should message with supplied message' do
@@ -51,7 +68,7 @@ describe CommandFlag do
 
       it 'should report the value' do
         pending 'this functionality has been temporarily removed'
-        expect(subject.value).to be(nil)
+        expect(subject.value).to eq(nil)
       end
 
       it 'should message with information about value' do
@@ -68,11 +85,11 @@ describe CommandFlag do
       it_behaves_like 'a Command Flag object'
 
       it 'should report the value' do
-        expect(subject.value).to be(value)
+        expect(subject.value).to eq(value)
       end
 
       it 'should message with information about value' do
-        expected_message = /The CLI flag #{flag} will be used with value #{value}./
+        expected_message = /The CLI flag '#{flag}' will be used with value '#{value}'./
         expect(subject.message).to match(expected_message)
       end
     end
@@ -105,9 +122,116 @@ describe CommandFlag do
       ENV[override_env_val] = value
 
       it 'should report that the flag will not be used' do
-        expected_message = /The CLI flag #{flag} will be used with value #{value}./
+        expected_message = /The CLI flag '#{flag}' will be used with value '#{value}'./
         expect(subject.message).to match(expected_message)
       end
     end
+
+    # default takes precedence in case the default state is "off" aka: empty
+    context 'with is_boolean' do
+
+      context 'should set switch to :name with no default and env_override not passed' do
+        let(:args) { {:name => flag, :is_boolean => true} }
+
+        it 'should report the switch name' do
+          expect(subject.flag).to eq(flag)
+        end
+        it 'should message with information about flag' do
+          expected_message = /The CLI switch '#{flag}' will be used./
+          expect(subject.message).to match(expected_message)
+        end
+        it 'should not have stop set to true' do
+          expect(subject.stop).to be_falsey
+        end
+      end
+
+      context 'should set switch to :name with no default and env_override passed but not set' do
+        let(:args) { {:name => flag, :is_boolean => true, :override_env => override_env} }
+
+        it 'should report the switch name' do
+          expect(subject.flag).to eq(flag)
+        end
+        it 'should message with information about flag' do
+          expected_message = /The CLI switch '#{flag}' will be used./
+          expect(subject.message).to match(expected_message)
+        end
+        it 'should not have stop set to true' do
+          expect(subject.stop).to be_falsey
+        end
+      end
+
+      context 'should set switch to :override_env with no default and env_override passed and set' do
+        let(:args) { {:name => flag, :is_boolean => true, :override_env => override_env} }
+
+        it 'should report the switch name' do
+          ENV[override_env] = value
+          expect(subject.flag).to eq(value)
+        end
+
+        # FIXME: repeated ENV setting here is problematic
+        #   doesn't work in before nor let.
+        it 'should message with information about flag' do
+          ENV[override_env] = value
+          expected_message = /The CLI switch '#{value}' will be used./
+          expect(subject.message).to match(expected_message)
+        end
+        it 'should not have stop set to true' do
+          expect(subject.stop).to be_falsey
+        end
+      end
+
+      context 'should set switch to :default over :name when env is not set so it can default to "off"' do
+        let(:args) { {:name => flag, :is_boolean => true, :default => value} }
+
+        it 'should report the switch name' do
+          expect(subject.flag).to eq(value)
+        end
+        it 'should message with information about flag' do
+          expected_message = /The CLI switch '#{value}' will be used./
+          expect(subject.message).to match(expected_message)
+        end
+        it 'should not have stop set to true' do
+          expect(subject.stop).to be_falsey
+        end
+      end
+
+      context 'should set switch to :default of ""' do
+        let(:args) { {:name => flag, :is_boolean => true, :default => ''} }
+
+        it 'should report the switch name' do
+          expect(subject.flag).to eq('')
+        end
+        it 'should message with information about flag' do
+          expected_message = /The CLI switch '#{flag}' will NOT be used./
+          expect(subject.message).to match(expected_message)
+        end
+        it 'should not have stop set to true' do
+          expect(subject.stop).to be_falsey
+        end
+      end
+
+      context 'should set switch to env_override when env is set with a :default' do
+        let(:args) { {:name => flag, :is_boolean => true, :default => value, :override_env => override_env} }
+        let(:env_val) { "env_#{value}" }
+
+        it 'should report the switch name' do
+          ENV[override_env] = env_val
+          expect(subject.flag).to eq(env_val)
+        end
+
+        # FIXME: repeated ENV setting here is problematic
+        #   doesn't work in before nor let.
+        it 'should message with information about flag' do
+          ENV[override_env] = env_val
+          expected_message = /The CLI switch '#{env_val}' will be used./
+          expect(subject.message).to match(expected_message)
+        end
+        it 'should not have stop set to true' do
+          expect(subject.stop).to be_falsey
+        end
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
We currently do not have a way to turn on and off switches, aka:
boolean-flags/options. This change adds a switch parameter to add_flag
to specify is_boolean.  The override_env now operates on the option
name, and the default value can be used to default the switch to 'off'.

This is bad and we should feel bad. the API if very warty and needs
refactoring. (post v0.1.0)
