### PR TITLE
(maint) use correct library when building gem

### DIFF
--- a/acceptance/pre-suite/01_install_rototiller.rb
+++ b/acceptance/pre-suite/01_install_rototiller.rb
@@ -1,4 +1,4 @@
-require 'rototiller/version'
+require_relative '../../lib/rototiller/version'
 
 gem_name = "rototiller-#{Rototiller::Version::STRING}.gem"
 teardown do


### PR DESCRIPTION
Before this change, acceptance would use any installed rototiller gem
for its version string when building the gem for acceptance. This would
cause issues if not using bundler, or had some old version of the gem.
And we have this info right relatively here, let's use it.
