### PR TITLE
(QA-2477) add flag with no command set should error

### DIFF
--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -104,6 +104,7 @@ module Rototiller
       # @private
       def run_task
         print_messages
+        raise ArgumentError.new("flags set with no command") if @flags && !@command.name
         command_str = [
             (@command.name if @command.name), @flags.to_s, (@command.argument if @command.argument)
         ].delete_if{ |i| [nil, '', false].any?{|forbidden| i == forbidden}}.join(' ')

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -168,6 +168,11 @@ module Rototiller::Task
         it "raises argument error for too many flag args" do
           expect{ task.add_flag('-t', '-t description', 'tvalue2', 'someother') }.to raise_error(ArgumentError)
         end
+        it "raises argument error when flags used with no command" do
+          task.add_command({:name => nil})
+          task.add_flag({:name => '--blah', :default => ''})
+          expect{ described_run_task }.to raise_error(ArgumentError)
+        end
       end
       context 'with env vars' do
       # add_env(EnvVar.new(), EnvVar.new(), EnvVar.new())


### PR DESCRIPTION
A simple fix that should never happen, unless the user forcibly removes
the command (that currently has a default).
