### PR TITLE
(qa-2478) refactor rototiller acceptance repeated code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,12 @@ rototiller_task :acceptance => [:generate_host_config] do |t|
 
   # with new block syntax
   t.add_flag do |flag|
+    flag.name = '--log-level'
+    flag.default ="verbose"
+    flag.message = 'beaker log-level'
+    flag.override_env = 'BEAKER_LOG_LEVEL'
+  end
+  t.add_flag do |flag|
     flag.name = '--hosts'
     flag.default = 'acceptance/hosts.cfg'
     flag.message = 'The configuration file that Beaker will use'
@@ -37,7 +43,7 @@ rototiller_task :acceptance => [:generate_host_config] do |t|
     flag.name = '--preserve-hosts'
     flag.default = 'onfail'
     flag.message = 'The beaker setting to preserve a provisioned host'
-    flag.override_env = 'BEAKER_PRESERVE-HOSTS'
+    flag.override_env = 'BEAKER_PRESERVE_HOSTS'
   end
   t.add_flag do |flag|
     flag.name = '--keyfile'
@@ -49,13 +55,13 @@ rototiller_task :acceptance => [:generate_host_config] do |t|
     flag.name = '--load-path'
     flag.default = 'acceptance/lib'
     flag.message = 'The load path Beaker will use'
-    flag.override_env = "BEAKER_LOAD-PATH"
+    flag.override_env = "BEAKER_LOAD_PATH"
   end
   t.add_flag do |flag|
     flag.name = '--pre-suite'
     flag.default = 'acceptance/pre-suite'
     flag.message = 'THe path to a directory containing pre-suites'
-    flag.override_env = "BEAKER_PRE-SUITE"
+    flag.override_env = "BEAKER_PRE_SUITE"
   end
   t.add_flag do |flag|
     flag.name = '--tests'

--- a/acceptance/lib/rakefile_tools.rb
+++ b/acceptance/lib/rakefile_tools.rb
@@ -1,16 +1,16 @@
 module RakefileTools
+
   def create_rakefile_on(sut, rakefile_contents)
-    step 'Copy rake file to SUT' do
-      path_to_rakefile = '/root/Rakefile'
+    # using blocks for step in here causes beaker to not un-indent log
+    step 'Copy rake file to SUT'
+    path_to_rakefile = '/root/Rakefile'
 
-      teardown do
-        step 'Remove Rakefile on SUT' do
-          on(sut, "rm -f #{path_to_rakefile}" )
-        end
-      end
-
-      create_remote_file(sut, path_to_rakefile, rakefile_contents)
-      return path_to_rakefile
+    teardown do
+      step 'Remove Rakefile on SUT'
+      on(sut, "rm -f #{path_to_rakefile}" )
     end
+
+    create_remote_file(sut, path_to_rakefile, rakefile_contents)
+    return path_to_rakefile
   end
 end

--- a/acceptance/lib/rakefile_tools.rb
+++ b/acceptance/lib/rakefile_tools.rb
@@ -3,12 +3,9 @@ module RakefileTools
   def create_rakefile_on(sut, rakefile_contents)
     # using blocks for step in here causes beaker to not un-indent log
     step 'Copy rake file to SUT'
-    path_to_rakefile = '/root/Rakefile'
-
-    teardown do
-      step 'Remove Rakefile on SUT'
-      on(sut, "rm -f #{path_to_rakefile}" )
-    end
+    # bit hackish.  find name of calling file (from the stack) minus the extension
+    test_name = File.basename(caller[0].split(':')[0], '.*')
+    path_to_rakefile = "/tmp/Rakefile_#{test_name}_#{random_string}"
 
     create_remote_file(sut, path_to_rakefile, rakefile_contents)
     return path_to_rakefile

--- a/acceptance/lib/rakefile_tools.rb
+++ b/acceptance/lib/rakefile_tools.rb
@@ -13,4 +13,13 @@ module RakefileTools
     create_remote_file(sut, path_to_rakefile, rakefile_contents)
     return path_to_rakefile
   end
+
+  def rototiller_rakefile_header
+    header = <<-HEADER
+      $LOAD_PATH.unshift('/root/rototiller/lib')
+      require 'rototiller'
+
+    HEADER
+  end
+
 end

--- a/acceptance/lib/rakefile_tools.rb
+++ b/acceptance/lib/rakefile_tools.rb
@@ -11,6 +11,36 @@ module RakefileTools
     return path_to_rakefile
   end
 
+  def create_rakefile_task_segment(segment_configs)
+    segment = ''
+    segment_configs.each do |this_segment|
+      if this_segment[:type] == :env
+        sut.add_env_var(this_segment[:name], "#{this_segment[:name]}: env present value") if this_segment[:exists]
+        add_type = 'add_env'
+      elsif this_segment[:type] == :option
+        sut.add_env_var(this_segment[:override_env], "#{this_segment[:override_env]}: env present value") if this_segment[:exists]
+        add_type = 'add_flag'
+      elsif this_segment[:type] == :switch
+        sut.add_env_var(this_segment[:override_env], this_segment[:env_value]) if this_segment[:override_env]
+        add_type = 'add_flag'
+      end
+      if this_segment[:block_syntax]
+        segment += "t.#{add_type} do |this_segment|\n"
+        remove_reserved_keys(this_segment).each do |k, v|
+          segment += "  this_segment.#{k.to_s} = '#{v}'\n"
+        end
+        segment += "end\n"
+      else
+        segment += "  t.#{add_type}({"
+        remove_reserved_keys(this_segment).each do |k, v|
+          segment += ":#{k} => '#{v}',"
+        end
+        segment += "})\n"
+      end
+    end
+    return segment
+  end
+
   def rototiller_rakefile_header
     header = <<-HEADER
       $LOAD_PATH.unshift('/root/rototiller/lib')

--- a/acceptance/lib/test_utilities.rb
+++ b/acceptance/lib/test_utilities.rb
@@ -36,7 +36,7 @@ module TestUtilities
     end
   end
 
-  RESERVED_KEYS = [:block_syntax, :env_value, :exists]
+  RESERVED_KEYS = [:block_syntax, :env_value, :exists, :type]
   def remove_reserved_keys(h)
     hash = h.dup
     RESERVED_KEYS.each do |key|

--- a/acceptance/lib/test_utilities.rb
+++ b/acceptance/lib/test_utilities.rb
@@ -34,4 +34,13 @@ module TestUtilities
     end
   end
 
+  RESERVED_KEYS = [:block_syntax, :env_value, :exists]
+  def remove_reserved_keys(h)
+    hash = h.dup
+    RESERVED_KEYS.each do |key|
+      hash.delete(key)
+    end
+    return hash
+  end
+
 end

--- a/acceptance/lib/test_utilities.rb
+++ b/acceptance/lib/test_utilities.rb
@@ -1,7 +1,7 @@
 module TestUtilities
 
   def random_string
-    (0...10).map { ('a'..'z').to_a[rand(26)] }.join.upcase
+    [*('a'..'z'),*('0'..'9')].shuffle[0,6].join
   end
 
   def set_random_env_on(host)
@@ -25,9 +25,11 @@ module TestUtilities
     return env_var
   end
 
-  def execute_task_on(host, task_name)
+  def execute_task_on(host, task_name=nil, rakefile_path=nil)
     step "Execute task '#{task_name}', ensure success"
-    on(host, "rake #{task_name}", :accept_all_exit_codes => true) do |result|
+    command = "rake #{task_name}"
+    command = command + " --rakefile #{rakefile_path}" if rakefile_path
+    on(host, command, :accept_all_exit_codes => true) do |result|
       assert(result.exit_code == 0, "Unexpected exit code: #{result.exit_code}")
       assert_no_match(/error/i, result.output, "An unexpected error was observed: '#{result.output}'")
       return result

--- a/acceptance/lib/test_utilities.rb
+++ b/acceptance/lib/test_utilities.rb
@@ -11,7 +11,6 @@ module TestUtilities
   end
 
   def unique_env_on(host)
-
     env = {}
     env_var = random_string
 
@@ -25,4 +24,14 @@ module TestUtilities
     env_var = random_string until !env[env_var]
     return env_var
   end
+
+  def execute_task_on(host, task_name)
+    step "Execute task '#{task_name}', ensure success"
+    on(host, "rake #{task_name}", :accept_all_exit_codes => true) do |result|
+      assert(result.exit_code == 0, "Unexpected exit code: #{result.exit_code}")
+      assert_no_match(/error/i, result.output, "An unexpected error was observed: '#{result.output}'")
+      return result
+    end
+  end
+
 end

--- a/acceptance/tests/rototillerTask/command_arguments_with_override.rb
+++ b/acceptance/tests/rototillerTask/command_arguments_with_override.rb
@@ -30,7 +30,7 @@ end
     sut.add_env_var(override_env, env_value)
     sut.add_env_var(argument_override_env, argument_env_key)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       # command was used that was supplied by the override_env
       assert_match(/^#{env_key} #{argument_env_key}/, result.stdout, 'The correct command was not observed')
     end
@@ -57,7 +57,7 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       command_regex = /#{validation_string} #{argument_validation_string}/
       assert_match(command_regex, result.stdout, 'The correct command was not observed')
     end

--- a/acceptance/tests/rototillerTask/command_arguments_with_override.rb
+++ b/acceptance/tests/rototillerTask/command_arguments_with_override.rb
@@ -19,9 +19,7 @@ test_name 'C97824: can set command arguments in a RototillerTask' do
 
     @task_name    = 'command_with_args_and_defaults'
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 rototiller_task :#{@task_name} do |t|
     t.add_command({:name => 'echo', :override_env => '#{override_env}', :argument => '#{default_arg}', :argument_override_env => '#{argument_override_env}'})
 end
@@ -50,9 +48,7 @@ end
     argument_validation_string = random_string
 
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 rototiller_task :#{@task_name} do |t|
     t.add_command do |c|
       c.name = 'echo #{validation_string}'

--- a/acceptance/tests/rototillerTask/command_arguments_with_override.rb
+++ b/acceptance/tests/rototillerTask/command_arguments_with_override.rb
@@ -24,18 +24,15 @@ rototiller_task :#{@task_name} do |t|
     t.add_command({:name => 'echo', :override_env => '#{override_env}', :argument => '#{default_arg}', :argument_override_env => '#{argument_override_env}'})
 end
     EOS
+
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
+
     sut.add_env_var(override_env, env_value)
     sut.add_env_var(argument_override_env, argument_env_key)
-    step 'Execute task defined in rake task' do
-      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
-        # exit code & no error in output
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
 
-        # command was used that was supplied by the override_env
-        assert_match(/^#{env_key} #{argument_env_key}/, result.stdout, 'The correct command was not observed')
-      end
+    execute_task_on(sut, @task_name) do |result|
+      # command was used that was supplied by the override_env
+      assert_match(/^#{env_key} #{argument_env_key}/, result.stdout, 'The correct command was not observed')
     end
   end
 
@@ -60,15 +57,9 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    step 'Execute task defined in rake task' do
-      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
-
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
-
-        command_regex = /#{validation_string} #{argument_validation_string}/
-        assert_match(command_regex, result.stdout, 'The correct command was not observed')
-      end
+    execute_task_on(sut, @task_name) do |result|
+      command_regex = /#{validation_string} #{argument_validation_string}/
+      assert_match(command_regex, result.stdout, 'The correct command was not observed')
     end
   end
 end

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -27,14 +27,6 @@ test_name 'C97820: can set key/value flag in a RototillerTask' do
     return segment
   end
 
-  def remove_reserved_keys(h)
-    hash = h.dup
-    [:block_syntax].each do |key|
-      hash.delete(key)
-    end
-    return hash
-  end
-
   command_flags = [
       {:name => '--hash-syntax',  :default => 'wow such hash syntax'},
       {:name => '--use-a-block',   :default => 'wow much block syntax', :block_syntax => true}

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -41,12 +41,10 @@ test_name 'C97820: can set key/value flag in a RototillerTask' do
 
   @task_name    = 'command_flag_testing_key_value'
   rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-    #{create_rakefile_task_segment(command_flags)}
-    t.add_command({:name => 'echo'})
+  #{create_rakefile_task_segment(command_flags)}
+  t.add_command({:name => 'echo'})
 end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -43,7 +43,7 @@ end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-  execute_task_on(sut, @task_name) do |result|
+  execute_task_on(sut, @task_name, rakefile_path) do |result|
     command_flags.each do |flag|
       command_regex = /#{flag[:name]} #{flag[:default]}/
       rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{flag[:default]}'/

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -1,9 +1,11 @@
 require 'beaker/hosts'
 require 'rakefile_tools'
+require 'test_utilities'
 
 test_name 'C97820: can set key/value flag in a RototillerTask' do
   extend Beaker::Hosts
   extend RakefileTools
+  extend TestUtilities
 
   def create_rakefile_task_segment(flags)
     segment = ''
@@ -49,18 +51,13 @@ end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-  step 'Execute task defined in rake task' do
-    on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
-      # exit code & no error in output
-      assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-      assert_no_match(/error/i, result.output, 'An unexpected error was observed')
-
-      command_flags.each do |flag|
-        command_regex = /#{flag[:name]} #{flag[:default]}/
-        rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{flag[:default]}'/
-        assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
-        assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
-      end
+  execute_task_on(sut, @task_name) do |result|
+    command_flags.each do |flag|
+      command_regex = /#{flag[:name]} #{flag[:default]}/
+      rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{flag[:default]}'/
+      assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
+      assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
     end
   end
+
 end

--- a/acceptance/tests/rototillerTask/command_flags.rb
+++ b/acceptance/tests/rototillerTask/command_flags.rb
@@ -7,30 +7,11 @@ test_name 'C97820: can set key/value flag in a RototillerTask' do
   extend RakefileTools
   extend TestUtilities
 
-  def create_rakefile_task_segment(flags)
-    segment = ''
-    flags.each do |flag|
-      if flag[:block_syntax]
-        segment += "t.add_flag do |flag|\n"
-        remove_reserved_keys(flag).each do |k, v|
-          segment += "  flag.#{k.to_s} = '#{v}'\n"
-        end
-        segment += "end\n"
-      else
-        segment += "  t.add_flag({"
-        remove_reserved_keys(flag).each do |k, v|
-          segment += ":#{k} => '#{v}',"
-        end
-        segment += "})\n"
-      end
-    end
-    return segment
-  end
-
   command_flags = [
-      {:name => '--hash-syntax',  :default => 'wow such hash syntax'},
-      {:name => '--use-a-block',   :default => 'wow much block syntax', :block_syntax => true}
+      {:name => '--hash-syntax', :default => 'wow such hash syntax'},
+      {:name => '--use-a-block', :default => 'wow much block syntax', :block_syntax => true}
   ]
+  command_flags = command_flags.each{|e| e[:type] = :option }
 
 
   @task_name    = 'command_flag_testing_key_value'

--- a/acceptance/tests/rototillerTask/command_options.rb
+++ b/acceptance/tests/rototillerTask/command_options.rb
@@ -2,34 +2,34 @@ require 'beaker/hosts'
 require 'rakefile_tools'
 require 'test_utilities'
 
-test_name 'C97820: can set key/value flag in a RototillerTask' do
+test_name 'C97820: can set key/value option in a RototillerTask' do
   extend Beaker::Hosts
   extend RakefileTools
   extend TestUtilities
 
-  command_flags = [
+  command_options = [
       {:name => '--hash-syntax', :default => 'wow such hash syntax'},
       {:name => '--use-a-block', :default => 'wow much block syntax', :block_syntax => true}
   ]
-  command_flags = command_flags.each{|e| e[:type] = :option }
+  command_options = command_options.each{|e| e[:type] = :option }
 
 
-  @task_name    = 'command_flag_testing_key_value'
+  @task_name    = 'command_option_testing_key_value'
   rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-  #{create_rakefile_task_segment(command_flags)}
+  #{create_rakefile_task_segment(command_options)}
   t.add_command({:name => 'echo'})
 end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
   execute_task_on(sut, @task_name, rakefile_path) do |result|
-    command_flags.each do |flag|
-      command_regex = /#{flag[:name]} #{flag[:default]}/
-      rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{flag[:default]}'/
+    command_options.each do |option|
+      command_regex = /#{option[:name]} #{option[:default]}/
+      rototiller_output_regex = /The CLI option '#{option[:name]}' will be used with value '#{option[:default]}'/
       assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
-      assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
+      assert_match(rototiller_output_regex, result.stdout, "The option #{option[:name]} was not observed on the command line")
     end
   end
 

--- a/acceptance/tests/rototillerTask/command_switches.rb
+++ b/acceptance/tests/rototillerTask/command_switches.rb
@@ -44,7 +44,7 @@ test_name 'C97821: can set switches (boolean options) for commands in a Rototill
       {:name => '--nameB',                  :is_boolean => true, :override_env => 'NODEFAULT4',  :env_value => '',      :block_syntax => true},
       {:name => '--nameC',  :default => '', :is_boolean => true, :override_env => 'HASDEFAULT4', :env_value => '',      :block_syntax => true},
   ]
-
+  command_switches = command_switches.each{|e| e[:type] = :switch }
 
   @task_name    = test_filename
   rakefile_contents = <<-EOS

--- a/acceptance/tests/rototillerTask/command_switches.rb
+++ b/acceptance/tests/rototillerTask/command_switches.rb
@@ -54,9 +54,7 @@ test_name 'C97821: can set switches (boolean options) for commands in a Rototill
 
   @task_name    = test_filename
   rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
     t.add_command({:name => 'echo'})

--- a/acceptance/tests/rototillerTask/command_switches.rb
+++ b/acceptance/tests/rototillerTask/command_switches.rb
@@ -56,7 +56,7 @@ end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-  execute_task_on(sut, @task_name) do |result|
+  execute_task_on(sut, @task_name, rakefile_path) do |result|
     # i plainly refuse to re-implement rototiller's is_boolean option logic here
     expected_out = <<-HERE
 \e[32mThe CLI switch '--name1' will be used.\e[0m

--- a/acceptance/tests/rototillerTask/command_switches.rb
+++ b/acceptance/tests/rototillerTask/command_switches.rb
@@ -7,19 +7,19 @@ test_name 'C97821: can set switches (boolean options) for commands in a Rototill
 
   test_filename = File.basename(__FILE__, '.*')
 
-  def create_rakefile_task_segment(flags)
+  def create_rakefile_task_segment(switches)
     segment = ''
-    flags.each.with_index do |flag,index|
-      sut.add_env_var(flag[:override_env], flag[:env_value]) if flag[:override_env]
-      if flag[:block_syntax]
-        segment += "t.add_flag do |flag|\n"
-        remove_reserved_keys(flag).each do |k, v|
-          segment += "  flag.#{k.to_s} = '#{v}'\n"
+    switches.each.with_index do |switch,index|
+      sut.add_env_var(switch[:override_env], switch[:env_value]) if switch[:override_env]
+      if switch[:block_syntax]
+        segment += "t.add_flag do |switch|\n"
+        remove_reserved_keys(switch).each do |k, v|
+          segment += "  switch.#{k.to_s} = '#{v}'\n"
         end
         segment += "end\n"
       else
         segment += "  t.add_flag({"
-        remove_reserved_keys(flag).each do |k, v|
+        remove_reserved_keys(switch).each do |k, v|
           segment += ":#{k} => '#{v}',"
         end
         segment += "})\n"
@@ -36,7 +36,7 @@ test_name 'C97821: can set switches (boolean options) for commands in a Rototill
     return hash
   end
 
-  command_flags = [
+  command_switches = [
       {:name => '--name1',                  :is_boolean => true},
       {:name => '--name2',  :default => '', :is_boolean => true},
       {:name => '--name3',                  :is_boolean => true, :override_env => 'NODEFAULT1',  :env_value => 'VAL1'},
@@ -84,9 +84,9 @@ end
 \e[33mThe CLI switch '--nameC' will NOT be used.\e[0m
 
 --name1 VAL1 VAL2 --name7 VAL3 VAL4
-HERE
-      assert_equal(expected_out,result.output, 'output did not match')
+    HERE
+    assert_equal(expected_out,result.output, 'output did not match')
 
-    end
   end
+
 end

--- a/acceptance/tests/rototillerTask/command_switches.rb
+++ b/acceptance/tests/rototillerTask/command_switches.rb
@@ -30,14 +30,6 @@ test_name 'C97821: can set switches (boolean options) for commands in a Rototill
     return segment
   end
 
-  def remove_reserved_keys(h)
-    hash = h.dup
-    [:block_syntax, :env_value].each do |key|
-      hash.delete(key)
-    end
-    return hash
-  end
-
   command_switches = [
       {:name => '--name1',                  :is_boolean => true},
       {:name => '--name2',  :default => '', :is_boolean => true},

--- a/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
+++ b/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
@@ -54,7 +54,7 @@ EOS
       end
     end
 
-    execute_task_on(sut, "#{task[:init_method]}#{task[:description]}") do |result|
+    execute_task_on(sut, "#{task[:init_method]}#{task[:description]}", rakefile_path) do |result|
       assert_match(/#{options[:init_method]}#{options[:description]} #{@task_body_string}/, result.stdout, "The expected output from the task '#{options[:init_method]}#{options[:description]}' was not observed")
     end
   end

--- a/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
+++ b/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
@@ -42,7 +42,7 @@ EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
   tasks.each do |task|
-    step "Use the -T flag to test task '#{task[:task_name]}' description" do
+    step "Use the -T rake switch to test task '#{task[:task_name]}' description" do
       on(sut, "rake -T --rakefile #{rakefile_path}", :accept_all_exit_codes => true) do |result|
         assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
         assert_no_match(/error/i, result.output, 'An unexpected error was observed')

--- a/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
+++ b/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
@@ -1,9 +1,11 @@
 require 'beaker/hosts'
 require 'rakefile_tools'
+require 'test_utilities'
 
 test_name 'C97830: describe and list RototillerTasks' do
   extend Beaker::Hosts
   extend RakefileTools
+  extend TestUtilities
 
   @task_body_string = 'Lorem ipsum dolor sit amet'
   def create_rakefile_task_segment(options)
@@ -40,22 +42,21 @@ EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
   tasks.each do |task|
-    step "Use the -T flag to test task '#{task[:task_name]}' description"
-    on(sut, "rake -T --rakefile #{rakefile_path}", :accept_all_exit_codes => true) do |result|
-      assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-      assert_no_match(/error/i, result.output, 'An unexpected error was observed')
-      if task[:description]
-        assert_match(/#{task[:init_method]}#{task[:description]}/, result.stdout, "The correct description '#{task[:init_method]}#{task[:description]}' was not observed")
-      else
-        assert_match(/#{task[:init_method]}\s+ # RototillerTask/, result.stdout, "The correct description '#{task[:init_method]}' was not observed")
+    step "Use the -T flag to test task '#{task[:task_name]}' description" do
+      on(sut, "rake -T --rakefile #{rakefile_path}", :accept_all_exit_codes => true) do |result|
+        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
+        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+        if task[:description]
+          assert_match(/#{task[:init_method]}#{task[:description]}/, result.stdout, "The correct description '#{task[:init_method]}#{task[:description]}' was not observed")
+        else
+          assert_match(/#{task[:init_method]}\s+ # RototillerTask/, result.stdout, "The correct description '#{task[:init_method]}' was not observed")
+        end
       end
     end
 
-    step "Execute task defined in rake task '#{task[:init_method]}#{task[:description]}'"
-    on(sut, "rake #{task[:init_method]}#{task[:description]}", :accept_all_exit_codes => true) do |result|
-      assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-      assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+    execute_task_on(sut, "#{task[:init_method]}#{task[:description]}") do |result|
       assert_match(/#{options[:init_method]}#{options[:description]} #{@task_body_string}/, result.stdout, "The expected output from the task '#{options[:init_method]}#{options[:description]}' was not observed")
     end
   end
+
 end

--- a/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
+++ b/acceptance/tests/rototillerTask/define_and_list_RototillerTasks.rb
@@ -31,11 +31,7 @@ EOS
     {:init_method => :dsl, :description => 'yep'},
   ]
 
-  rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
-  EOS
+  rakefile_contents = rototiller_rakefile_header
 
   tasks.each do |task|
     rakefile_contents = rakefile_contents + create_rakefile_task_segment(task)

--- a/acceptance/tests/rototillerTask/dependent_tasks.rb
+++ b/acceptance/tests/rototillerTask/dependent_tasks.rb
@@ -26,11 +26,11 @@ end
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     task_name = 'r_parent'
-    execute_task_on(sut, task_name) do |result|
+    execute_task_on(sut, task_name, rakefile_path) do |result|
       assert_match(/tiller child.*native child.*tiller parent/m, result.output, 'r_parent: not all children were called')
     end
     task_name = 'parent'
-    execute_task_on(sut, task_name) do |result|
+    execute_task_on(sut, task_name, rakefile_path) do |result|
       assert_match(/tiller child.*native child.*native parent/m, result.output, 'parent: not all children were called')
     end
   end

--- a/acceptance/tests/rototillerTask/dependent_tasks.rb
+++ b/acceptance/tests/rototillerTask/dependent_tasks.rb
@@ -1,9 +1,11 @@
 require 'beaker/hosts'
 require 'rakefile_tools'
+require 'test_utilities'
 
 test_name 'C97794: ensure RototillerTasks can be parent/child tasks' do
   extend Beaker::Hosts
   extend RakefileTools
+  extend TestUtilities
 
   ['rototiller_task', 'Rototiller::Task::RototillerTask.define_task'].each do |new_task_method|
     rakefile_contents = <<-EOS
@@ -21,19 +23,16 @@ Rototiller::Task::RototillerTask.define_task :r_parent => [:r_child, :child] do 
   t.add_command({:name => 'echo "i am the tiller parent"'})
 end
   EOS
-  rakefile_path = create_rakefile_on(sut, rakefile_contents)
+    rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    step "Execute task defined in rake task 'r_parent'" do
-      on(sut, "rake r_parent", :accept_all_exit_codes => true) do |result|
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
-        assert_match(/tiller child.*native child.*tiller parent/m, result.output, 'r_parent: not all children were called')
-      end
-      on(sut, "rake parent", :accept_all_exit_codes => true) do |result|
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
-        assert_match(/tiller child.*native child.*native parent/m, result.output, 'parent: not all children were called')
-      end
+    task_name = 'r_parent'
+    execute_task_on(sut, task_name) do |result|
+      assert_match(/tiller child.*native child.*tiller parent/m, result.output, 'r_parent: not all children were called')
+    end
+    task_name = 'parent'
+    execute_task_on(sut, task_name) do |result|
+      assert_match(/tiller child.*native child.*native parent/m, result.output, 'parent: not all children were called')
     end
   end
+
 end

--- a/acceptance/tests/rototillerTask/dependent_tasks.rb
+++ b/acceptance/tests/rototillerTask/dependent_tasks.rb
@@ -7,9 +7,7 @@ test_name 'C97794: ensure RototillerTasks can be parent/child tasks' do
 
   ['rototiller_task', 'Rototiller::Task::RototillerTask.define_task'].each do |new_task_method|
     rakefile_contents = <<-EOS
-  $LOAD_PATH.unshift('/root/rototiller/lib')
-  require 'rototiller'
-
+#{rototiller_rakefile_header}
 task :child do |t|
   system('echo "i am the native child"')
 end

--- a/acceptance/tests/rototillerTask/environment_variables.rb
+++ b/acceptance/tests/rototillerTask/environment_variables.rb
@@ -53,7 +53,7 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       env_vars.each do |env|
         # validate notification to user of ENV value
         rototiller_message_match = env[:exists] ?
@@ -87,7 +87,7 @@ end
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     step 'Execute task defined in rake task' do
-      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
+      on(sut, "rake #{@task_name} --rakefile #{rakefile_path}", :accept_all_exit_codes => true) do |result|
         # exit code & no error in output
         assert(result.exit_code == 1, 'The expected exit code 1 was not observed')
 

--- a/acceptance/tests/rototillerTask/environment_variables.rb
+++ b/acceptance/tests/rototillerTask/environment_variables.rb
@@ -52,9 +52,7 @@ test_name 'C97797: ensure environment variable operation in RototillerTasks' do
 
     @task_name    = 'env_var_testing_task'
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(env_vars)}
 end
@@ -93,9 +91,7 @@ end
        :exists => false},
     ]
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(env_vars_fail)}
 end

--- a/acceptance/tests/rototillerTask/environment_variables.rb
+++ b/acceptance/tests/rototillerTask/environment_variables.rb
@@ -7,27 +7,6 @@ test_name 'C97797: ensure environment variable operation in RototillerTasks' do
   extend RakefileTools
   extend TestUtilities
 
-  def create_rakefile_task_segment(envs)
-    segment = ''
-    envs.each do |env|
-      sut.add_env_var(env[:name], "#{env[:name]}: present value") if env[:exists]
-      if env[:block_syntax]
-        segment += "t.add_env do |env|\n"
-        remove_reserved_keys(env).each do |k, v|
-          segment += "  env.#{k.to_s} = '#{v}'\n"
-        end
-        segment += "end\n"
-      else
-        segment += "  t.add_env({"
-        remove_reserved_keys(env).each do |k, v|
-          segment += ":#{k} => '#{v}',"
-        end
-        segment += "})\n"
-      end
-    end
-    return segment
-  end
-
   step 'For environment variables that will succeed' do
     env_vars = [
       {:name => 'NO_DEFAULT-EXISTS',        :message => 'no default, previously exists',
@@ -43,6 +22,7 @@ test_name 'C97797: ensure environment variable operation in RototillerTasks' do
       {:name => 'NO_DEFAULT-EXISTS-BLOCK',  :message => 'no default, previously exists',
        :exists => true,   :block_syntax => true},
     ]
+    env_vars = env_vars.each{|e| e[:type] = :env }
 
     @task_name    = 'env_var_testing_task'
     rakefile_contents = <<-EOS
@@ -78,6 +58,8 @@ end
       {:name => 'NO_DEFAULT-NO_EXISTS-BLOCK', :message => 'no default, does not previously exist',
        :exists => false},
     ]
+    env_vars_fail = env_vars_fail.each{|e| e[:type] = :env }
+
     rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|

--- a/acceptance/tests/rototillerTask/environment_variables.rb
+++ b/acceptance/tests/rototillerTask/environment_variables.rb
@@ -28,14 +28,6 @@ test_name 'C97797: ensure environment variable operation in RototillerTasks' do
     return segment
   end
 
-  def remove_reserved_keys(h)
-    hash = h.dup
-    [:block_syntax, :exists].each do |key|
-      hash.delete(key)
-    end
-    return hash
-  end
-
   step 'For environment variables that will succeed' do
     env_vars = [
       {:name => 'NO_DEFAULT-EXISTS',        :message => 'no default, previously exists',

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -47,7 +47,7 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       command_flags.each do |flag|
         value = flag[:default] || "#{flag[:override_env]}: env present value"
         command_regex = /#{flag[:name]} #{value}/
@@ -77,7 +77,7 @@ end
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     step 'Execute task defined in rake task' do
-      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
+      on(sut, "rake #{@task_name} --rakefile #{rakefile_path}", :accept_all_exit_codes => true) do |result|
         assert(result.exit_code == 1, 'The expected exit code 1 was not observed')
         assert_no_match(/error/i, result.output, 'An unexpected error was observed')
 
@@ -106,7 +106,7 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       command_flags.each do |flag|
         regex = /The CLI flag #{flag[:name]} has no value assigned and will not be included./
         assert_match(regex, result.stdout, "The expected output from rototiller for an optional flag was not observed.")

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -55,20 +55,14 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    step 'Execute task defined in rake task' do
-      on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
-        # exit code & no error in output
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed')
+    execute_task_on(sut, @task_name) do |result|
+      command_flags.each do |flag|
+        value = flag[:default] || "#{flag[:override_env]}: env present value"
+        command_regex = /#{flag[:name]} #{value}/
+        rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{value}'/
 
-        command_flags.each do |flag|
-          value = flag[:default] || "#{flag[:override_env]}: env present value"
-          command_regex = /#{flag[:name]} #{value}/
-          rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{value}'/
-
-          assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
-          assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
-        end
+        assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
+        assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
       end
     end
   end
@@ -91,9 +85,7 @@ end
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     step 'Execute task defined in rake task' do
-
       on(sut, "rake #{@task_name}", :accept_all_exit_codes => true) do |result|
-        # exit code & no error in output
         assert(result.exit_code == 1, 'The expected exit code 1 was not observed')
         assert_no_match(/error/i, result.output, 'An unexpected error was observed')
 
@@ -122,18 +114,12 @@ end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    step 'Execute task defined in rake task' do
-
-      on(sut, "rake #{@task_name} #{override}=''", :accept_all_exit_codes => true) do |result|
-        # exit code & no error in output
-        assert(result.exit_code == 0, 'The expected exit code 0 was not observed, (non-required flags)')
-        assert_no_match(/error/i, result.output, 'An unexpected error was observed (non-required flags)')
-
-        command_flags.each do |flag|
-          regex = /The CLI flag #{flag[:name]} has no value assigned and will not be included./
-          assert_match(regex, result.stdout, "The expected output from rototiller for an optional flag was not observed.")
-        end
+    execute_task_on(sut, @task_name) do |result|
+      command_flags.each do |flag|
+        regex = /The CLI flag #{flag[:name]} has no value assigned and will not be included./
+        assert_match(regex, result.stdout, "The expected output from rototiller for an optional flag was not observed.")
       end
     end
   end
+
 end

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -28,14 +28,6 @@ test_name 'C97798: existing workflows shall be supported for using ENV vars to o
     return segment
   end
 
-  def remove_reserved_keys(h)
-    hash = h.dup
-    [:block_syntax, :exists].each do |key|
-      hash.delete(key)
-    end
-    return hash
-  end
-
   step 'Test flags that will let command continue' do
 
     test_filename = File.basename(__FILE__, '.*')

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -7,34 +7,14 @@ test_name 'C97798: existing workflows shall be supported for using ENV vars to o
   extend RakefileTools
   extend TestUtilities
 
-  def create_rakefile_task_segment(flags)
-    segment = ''
-    flags.each do |flag|
-      sut.add_env_var(flag[:override_env], "#{flag[:override_env]}: env present value") if flag[:exists]
-      if flag[:block_syntax]
-        segment += "t.add_flag do |flag|\n"
-        remove_reserved_keys(flag).each do |k, v|
-          segment += "  flag.#{k.to_s} = '#{v}'\n"
-        end
-        segment += "end\n"
-      else
-        segment += "  t.add_flag({"
-        remove_reserved_keys(flag).each do |k, v|
-          segment += ":#{k} => '#{v}',"
-        end
-        segment += "})\n"
-      end
-    end
-    return segment
-  end
-
   step 'Test flags that will let command continue' do
 
     test_filename = File.basename(__FILE__, '.*')
     command_flags = [
       {:name => '--setenv-nodefault', :override_env => "NODEFAULT_#{test_filename.upcase}", :exists => true},
-      {:name => '--setenv-default', :block_syntax => true, :exists => true, :default => 'Author specified default'},
+      {:name => '--setenv-default',                                                         :exists => true, :default => 'Author specified default', :block_syntax => true},
     ]
+    command_flags = command_flags.each{|e| e[:type] = :option }
 
 
     @task_name    = 'command_flags_with_override'
@@ -65,6 +45,7 @@ end
     command_flags = [
       {:name => '--unset-nodefault', :override_env => 'NOTSET'},
     ]
+    command_flags = command_flags.each{|e| e[:type] = :option }
 
     @task_name    = 'command_flags_that_stop_rake'
     rakefile_contents = <<-EOS
@@ -95,6 +76,7 @@ end
         {:name => '--not-required', :override_env => 'required_override', :required => false},
         {:name => '--not-required-with-default', :override_env => override, :default => 'def_val', :required => false},
     ]
+    command_flags = command_flags.each{|e| e[:type] = :option }
 
     @task_name    = 'command_flags_that_stop_rake'
     rakefile_contents = <<-EOS

--- a/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_flag_with_env_var.rb
@@ -47,9 +47,7 @@ test_name 'C97798: existing workflows shall be supported for using ENV vars to o
 
     @task_name    = 'command_flags_with_override'
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
     t.add_command({:name => 'echo'})
@@ -79,14 +77,12 @@ end
 
     # todo flags that will stop
     command_flags = [
-        {:name => '--unset-nodefault', :override_env => 'NOTSET'},
+      {:name => '--unset-nodefault', :override_env => 'NOTSET'},
     ]
 
     @task_name    = 'command_flags_that_stop_rake'
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
     t.add_command({:name => 'echo'})
@@ -118,9 +114,7 @@ end
 
     @task_name    = 'command_flags_that_stop_rake'
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
+#{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
     #{create_rakefile_task_segment(command_flags)}
     t.add_command({:name => 'echo'})

--- a/acceptance/tests/rototillerTask/override_command_option_with_env_var.rb
+++ b/acceptance/tests/rototillerTask/override_command_option_with_env_var.rb
@@ -2,56 +2,56 @@ require 'beaker/hosts'
 require 'rakefile_tools'
 require 'test_utilities'
 
-test_name 'C97798: existing workflows shall be supported for using ENV vars to override command flags' do
+test_name 'C97798: existing workflows shall be supported for using ENV vars to override command options' do
   extend Beaker::Hosts
   extend RakefileTools
   extend TestUtilities
 
-  step 'Test flags that will let command continue' do
+  step 'Test options that will let command continue' do
 
     test_filename = File.basename(__FILE__, '.*')
-    command_flags = [
+    command_options = [
       {:name => '--setenv-nodefault', :override_env => "NODEFAULT_#{test_filename.upcase}", :exists => true},
       {:name => '--setenv-default',                                                         :exists => true, :default => 'Author specified default', :block_syntax => true},
     ]
-    command_flags = command_flags.each{|e| e[:type] = :option }
+    command_options = command_options.each{|e| e[:type] = :option }
 
 
-    @task_name    = 'command_flags_with_override'
+    @task_name    = 'command_options_with_override'
     rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-    #{create_rakefile_task_segment(command_flags)}
+    #{create_rakefile_task_segment(command_options)}
     t.add_command({:name => 'echo'})
 end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     execute_task_on(sut, @task_name, rakefile_path) do |result|
-      command_flags.each do |flag|
-        value = flag[:default] || "#{flag[:override_env]}: env present value"
-        command_regex = /#{flag[:name]} #{value}/
-        rototiller_output_regex = /The CLI flag '#{flag[:name]}' will be used with value '#{value}'/
+      command_options.each do |option|
+        value = option[:default] || "#{option[:override_env]}: env present value"
+        command_regex = /#{option[:name]} #{value}/
+        rototiller_output_regex = /The CLI flag '#{option[:name]}' will be used with value '#{value}'/
 
         assert_match(command_regex, result.stdout, "The expected output from rototiller was not observed")
-        assert_match(rototiller_output_regex, result.stdout, "The flag #{flag[:name]} was not observed on the command line")
+        assert_match(rototiller_output_regex, result.stdout, "The option #{option[:name]} was not observed on the command line")
       end
     end
   end
 
-  step 'Test flags that will stop the rake task' do
+  step 'Test options that will stop the rake task' do
 
-    # todo flags that will stop
-    command_flags = [
+    # todo options that will stop
+    command_options = [
       {:name => '--unset-nodefault', :override_env => 'NOTSET'},
     ]
-    command_flags = command_flags.each{|e| e[:type] = :option }
+    command_options = command_options.each{|e| e[:type] = :option }
 
-    @task_name    = 'command_flags_that_stop_rake'
+    @task_name    = 'command_options_that_stop_rake'
     rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-    #{create_rakefile_task_segment(command_flags)}
+    #{create_rakefile_task_segment(command_options)}
     t.add_command({:name => 'echo'})
 end
     EOS
@@ -62,36 +62,36 @@ end
         assert(result.exit_code == 1, 'The expected exit code 1 was not observed')
         assert_no_match(/error/i, result.output, 'An unexpected error was observed')
 
-        command_flags.each do |flag|
-          regex = /The CLI flag '#{flag[:name]}' needs a value.\nYou can specify this value with the environment variable '#{flag[:override_env]}'/
+        command_options.each do |option|
+          regex = /The CLI flag '#{option[:name]}' needs a value.\nYou can specify this value with the environment variable '#{option[:override_env]}'/
           assert_match(regex, result.stdout, "The expected output from rototiller was not observed")
         end
       end
     end
   end
 
-  step 'Test flags that are not required' do
+  step 'Test options that are not required' do
     override = random_string
-    command_flags = [
+    command_options = [
         {:name => '--not-required', :override_env => 'required_override', :required => false},
         {:name => '--not-required-with-default', :override_env => override, :default => 'def_val', :required => false},
     ]
-    command_flags = command_flags.each{|e| e[:type] = :option }
+    command_options = command_options.each{|e| e[:type] = :option }
 
-    @task_name    = 'command_flags_that_stop_rake'
+    @task_name    = 'command_options_that_stop_rake'
     rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
 Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-    #{create_rakefile_task_segment(command_flags)}
+    #{create_rakefile_task_segment(command_options)}
     t.add_command({:name => 'echo'})
 end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
     execute_task_on(sut, @task_name, rakefile_path) do |result|
-      command_flags.each do |flag|
-        regex = /The CLI flag #{flag[:name]} has no value assigned and will not be included./
-        assert_match(regex, result.stdout, "The expected output from rototiller for an optional flag was not observed.")
+      command_options.each do |option|
+        regex = /The CLI flag #{option[:name]} has no value assigned and will not be included./
+        assert_match(regex, result.stdout, "The expected output from rototiller for an optional option was not observed.")
       end
     end
   end

--- a/acceptance/tests/rototillerTask/override_command_with_env.rb
+++ b/acceptance/tests/rototillerTask/override_command_with_env.rb
@@ -23,7 +23,7 @@ test_name 'C97827: can set envvar to override command name when using task.comma
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
     sut.add_env_var(override_env, env_value)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       # command was used that was supplied by the override_env
       assert_match(/^#{env_key}/, result.stdout, 'The correct command was not observed')
     end
@@ -45,7 +45,7 @@ test_name 'C97827: can set envvar to override command name when using task.comma
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    execute_task_on(sut, @task_name) do |result|
+    execute_task_on(sut, @task_name, rakefile_path) do |result|
       assert_match(/#{validation_string}/, result.stdout, 'The correct command was not observed')
     end
   end

--- a/acceptance/tests/rototillerTask/override_command_with_env.rb
+++ b/acceptance/tests/rototillerTask/override_command_with_env.rb
@@ -13,12 +13,10 @@ test_name 'C97827: can set envvar to override command name when using task.comma
 
     @task_name    = 'command_flags_with_override'
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
-Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-    t.add_command({:name => 'echo', :override_env => '#{override_env}'})
-end
+      #{rototiller_rakefile_header}
+      Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
+          t.add_command({:name => 'echo', :override_env => '#{override_env}'})
+      end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
     sut.add_env_var(override_env, env_value)
@@ -44,15 +42,13 @@ end
     validation_string = (0...10).map { ('a'..'z').to_a[rand(26)] }.join
 
     rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
-Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
-    t.add_command do |c|
-      c.name = 'echo #{validation_string}'
-      c.override_env = '#{override_env}'
-    end
-end
+      #{rototiller_rakefile_header}
+      Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
+          t.add_command do |c|
+            c.name = 'echo #{validation_string}'
+            c.override_env = '#{override_env}'
+          end
+      end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 

--- a/acceptance/tests/rototillerTask/override_command_with_env.rb
+++ b/acceptance/tests/rototillerTask/override_command_with_env.rb
@@ -13,7 +13,7 @@ test_name 'C97827: can set envvar to override command name when using task.comma
     env_key = 'THIS_WAS_IN_ENV'
     env_value = 'echo ' << env_key
 
-    @task_name    = 'command_flags_with_override'
+    @task_name    = 'commands_with_override'
     rakefile_contents = <<-EOS
       #{rototiller_rakefile_header}
       Rototiller::Task::RototillerTask.define_task :#{@task_name} do |t|
@@ -31,7 +31,7 @@ test_name 'C97827: can set envvar to override command name when using task.comma
 
   step 'Add Command with block syntax and unset override_env' do
     override_env = 'EMPTYENV'
-    @task_name    = 'command_flags_with_override'
+    @task_name    = 'commands_with_override_no_value'
     validation_string = (0...10).map { ('a'..'z').to_a[rand(26)] }.join
 
     rakefile_contents = <<-EOS

--- a/acceptance/tests/rototillerTask/task_with_args.rb
+++ b/acceptance/tests/rototillerTask/task_with_args.rb
@@ -7,16 +7,14 @@ test_name 'C97795: ensure RototillerTasks can use arguments' do
 
   rake_task_name = 'sometask'
   rakefile_contents = <<-EOS
-$LOAD_PATH.unshift('/root/rototiller/lib')
-require 'rototiller'
-
-rototiller_task :#{rake_task_name}, [:arg1, :arg2] do |t, args|
-  if args[:arg2]
-    t.add_command({:name => "echo 'task args: #\{args\}'"})
-  else
-    t.add_command({:name => "echo 'task arg1: #\{args[:arg1]\}'"})
-  end
-end
+    #{rototiller_rakefile_header}
+    rototiller_task :#{rake_task_name}, [:arg1, :arg2] do |t, args|
+      if args[:arg2]
+        t.add_command({:name => "echo 'task args: #\{args\}'"})
+      else
+        t.add_command({:name => "echo 'task arg1: #\{args[:arg1]\}'"})
+      end
+    end
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 

--- a/acceptance/tests/rototillerTask/task_with_args.rb
+++ b/acceptance/tests/rototillerTask/task_with_args.rb
@@ -21,15 +21,15 @@ test_name 'C97795: ensure RototillerTasks can use command line arguments' do
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
   # DO NOT put a space btwn the args to rake!  boo
-  execute_task_on(sut, "#{rake_task_name}[1,3]") do |result|
+  execute_task_on(sut, "#{rake_task_name}[1,3]", rakefile_path) do |result|
     assert_match(/task args: {:arg1=>"1", :arg2=>"3"}/i, result.output, '2 int args not parsed properly')
   end
 
-  execute_task_on(sut, "#{rake_task_name}['val1','val2']") do |result|
+  execute_task_on(sut, "#{rake_task_name}['val1','val2']", rakefile_path) do |result|
     assert_match(/task args: {:arg1=>"val1", :arg2=>"val2"}/i, result.output, '2 string args not parsed properly')
   end
 
-  execute_task_on(sut, "#{rake_task_name}['val1']") do |result|
+  execute_task_on(sut, "#{rake_task_name}['val1']", rakefile_path) do |result|
     assert_match(/task arg1: val1/i, result.output, '1 string arg not parsed properly')
   end
 

--- a/acceptance/tests/rototillerTask/task_with_args.rb
+++ b/acceptance/tests/rototillerTask/task_with_args.rb
@@ -1,9 +1,11 @@
 require 'beaker/hosts'
 require 'rakefile_tools'
+require 'test_utilities'
 
-test_name 'C97795: ensure RototillerTasks can use arguments' do
+test_name 'C97795: ensure RototillerTasks can use command line arguments' do
   extend Beaker::Hosts
   extend RakefileTools
+  extend TestUtilities
 
   rake_task_name = 'sometask'
   rakefile_contents = <<-EOS
@@ -18,17 +20,17 @@ test_name 'C97795: ensure RototillerTasks can use arguments' do
   EOS
   rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-  step "Execute task defined in rake task '#{rake_task_name}'" do
-    # DO NOT put a space btwn the args to rake!  boo
-    on(sut, "rake #{rake_task_name}[1,3]") do |result|
-      assert_match(/task args: {:arg1=>"1", :arg2=>"3"}/i, result.output, '2 int args not parsed properly')
-    end
-    on(sut, "rake #{rake_task_name}['val1','val2']") do |result|
-      assert_match(/task args: {:arg1=>"val1", :arg2=>"val2"}/i, result.output, '2 string args not parsed properly')
-    end
-    on(sut, "rake #{rake_task_name}['val1']") do |result|
-      assert_match(/task arg1: val1/i, result.output, '1 string arg not parsed properly')
-    end
+  # DO NOT put a space btwn the args to rake!  boo
+  execute_task_on(sut, "#{rake_task_name}[1,3]") do |result|
+    assert_match(/task args: {:arg1=>"1", :arg2=>"3"}/i, result.output, '2 int args not parsed properly')
+  end
+
+  execute_task_on(sut, "#{rake_task_name}['val1','val2']") do |result|
+    assert_match(/task args: {:arg1=>"val1", :arg2=>"val2"}/i, result.output, '2 string args not parsed properly')
+  end
+
+  execute_task_on(sut, "#{rake_task_name}['val1']") do |result|
+    assert_match(/task arg1: val1/i, result.output, '1 string arg not parsed properly')
   end
 
 end


### PR DESCRIPTION
- abstract the rakefile segment generation
  - The rakefile segment generation method was very similar across tests. Move it to a library. It could probably use some clarity and more fanciness, but this works for now and should allow us to more easily create tests for api v2.
- create unique Rakefile per test
  - Previously we were just putting a Rakefile in /root. This is great for using the default rake behavior of finding Rakefiles. but is difficult to debug when tests fail.  Now we place a unique-per-run Rakefile in /tmp and specify that file for rake to run.
- abstract remove_reserved_keys out of tests
- abstract rake task execution out of tests
- rename some "flag" usage to "switch" in tests
- abstract rakefile headers, remove from tests
  - the header for the Rakefiles used in tests were repeated across all tests. Here we abstract this into a module
- remove step blocks in modules
  - steps with blocks in modules causes beaker to not un-indent the logging
    properly, remove these.  :-(
