### PR TITLE
(QA-2517) test against rake 11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development do
   # restrict version to enable ruby 1.9.3
   gem 'mime-types'           ,'~> 2.0'
   gem 'google-api-client'    ,'<= 0.9.4'
+  gem 'activesupport'        ,'< 5.0.0'
 end
 
 local_gemfile = "#{__FILE__}.local"

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ end
 rototiller_task :acceptance => [:generate_host_config] do |t|
   # with a hash
   t.add_env({:name => 'TEST_TARGET',:default => 'centos7-64', :message => 'The argument to pass to beaker-hostgenerator'})
+  t.add_env({:name => 'RAKE_VER',   :default => '11.0',       :message => 'The rake version to use when running acceptance tests'})
 
   # with new block syntax
   t.add_flag do |flag|
@@ -67,6 +68,7 @@ rototiller_task :acceptance => [:generate_host_config] do |t|
   t.add_command({:name => 'beaker --debug', :override_env => 'BEAKER_EXECUTABLE'})
 end
 
-Rototiller::Task::RototillerTask.define_task :check_test do |t|
+rototiller_task :check_test do |t|
   t.add_env({:name => 'SPEC_PATTERN', :default => 'spec/', :message => 'The pattern RSpec will use to find tests'})
+  t.add_env({:name => 'RAKE_VER',     :default => '11.0',  :message => 'The rake version to use when running unit tests'})
 end

--- a/acceptance/pre-suite/02_install_rake.rb
+++ b/acceptance/pre-suite/02_install_rake.rb
@@ -1,4 +1,4 @@
 sut = find_only_one('agent')
-on(sut, 'gem install rake')
 
-#TODO in the future use bundler to determine the version of rake
+rake_version = `rake --version`.split[2]
+on(sut, "gem install rake -v #{rake_version}")

--- a/rototiller.gemspec
+++ b/rototiller.gemspec
@@ -16,5 +16,8 @@ Gem::Specification.new do |s|
   s.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
 
   #Run time dependencies
-  s.add_runtime_dependency 'rake', '>= 0.9.0'
+  rake_version = ENV['RAKE_VER'] || '11.0'
+  # RAKE_VER=0.9, 10.0, 11.0
+  #   don't use 11.0.0, which probably installs 11.0.1 which has issues
+  s.add_runtime_dependency 'rake', "~> #{rake_version}"
 end


### PR DESCRIPTION
(QA-2517) enable testing/building against different rake versions

related to:
https://github.com/puppetlabs/ci-job-configs/pull/1533

if testing against the non-default rake version of `~> 11.0`
use `RAKE_VER=0.9 bundle install` followed by `RAKE_VER=0.9 bundle exec rake acceptance`
you have to always specify the RAKE_VER if not using the default, because... bundler

this should work for both unit tests and acceptance. 
the ci-job-configs PR above makes changes for the unit test job.  the acceptance job needs more work.

note: this is targeted at stable and will need to be merged up to master.  we also still have to setup CI jobs for stable, if we're going to continue with the stable and master/dev branches.
