### PR TITLE
(QA-2637) command: #add env

### DIFF
--- a/Rakefile.example
+++ b/Rakefile.example
@@ -1,0 +1,23 @@
+require 'rototiller'
+
+# This example Rakefile should be kept in sync with the README.md file
+# This can be used by us and users as an example for all functionality
+
+desc "parent task for dependent tasks. this one also uses two environment variables and two commands"
+rototiller_task :parent_task do |task|
+  # most method initializers take either a hash, or block syntax (see next task)
+  task.add_env({:name     => 'RANDOM_VAR', :default => 'default value'})
+  task.add_env({:name     => 'RANDOM_VAR2', :default => 'default value2'})
+  task.add_command({:name => "echo 'i am running this command with $RANDOM_VAR = #{ENV['RANDOM_VAR']}'"})
+  task.add_command({:name => "echo 'some other command!'"})
+end
+
+desc "override command-name with environment variable"
+rototiller_task :child => :parent_task do |task|
+  task.add_command({:name => 'nonesuch', :add_env => {:name => 'COMMAND_EXE1'}})
+  # block syntax here. We give up some lines for more readability
+  task.add_command do |cmd|
+    cmd.name = 'meneither'
+    cmd.add_env({:name => 'COMMAND_EXE2'})
+  end
+end

--- a/acceptance/tests/rototillerTask/command_arguments_with_override.rb
+++ b/acceptance/tests/rototillerTask/command_arguments_with_override.rb
@@ -2,63 +2,52 @@ require 'beaker/hosts'
 require 'rakefile_tools'
 require 'test_utilities'
 
-test_name 'C97824: can set command arguments in a RototillerTask' do
+test_name 'C97824: can set command arguments and overrides in a RototillerTask' do
   extend Beaker::Hosts
   extend RakefileTools
   extend TestUtilities
 
-  step 'Test command with an override_env that has a value' do
-
-    override_env = unique_env_on(sut)
+  step 'Test command argument with an override_env that has a value' do
     argument_override_env = unique_env_on(sut)
-    env_key = 'THIS_WAS_IN_ENV'
-    argument_env_key = 'THIS_WAS_THE_ARG_IN_THE_ENV'
-    env_value = 'echo ' << env_key
-
+    argument_env_value = 'THIS_WAS_THE_ARG_IN_THE_ENV'
     default_arg = 'HANKVENTURE'
+    task_name    = 'command_with_args_and_defaults'
 
-    @task_name    = 'command_with_args_and_defaults'
     rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
-rototiller_task :#{@task_name} do |t|
-    t.add_command({:name => 'echo', :override_env => '#{override_env}', :argument => '#{default_arg}', :argument_override_env => '#{argument_override_env}'})
+rototiller_task :#{task_name} do |t|
+    t.add_command({:name => 'echo', :argument => '#{default_arg}', :argument_override_env => '#{argument_override_env}'})
 end
     EOS
 
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
+    sut.add_env_var(argument_override_env, argument_env_value)
 
-    sut.add_env_var(override_env, env_value)
-    sut.add_env_var(argument_override_env, argument_env_key)
-
-    execute_task_on(sut, @task_name, rakefile_path) do |result|
-      # command was used that was supplied by the override_env
-      assert_match(/^#{env_key} #{argument_env_key}/, result.stdout, 'The correct command was not observed')
+    execute_task_on(sut, task_name, rakefile_path) do |result|
+      assert_match(/^#{argument_env_value}/, result.stdout, 'The correct command was not observed')
     end
   end
 
-  step 'Add Command with block syntax and unset override_env' do
-
-    override_env = unique_env_on(sut)
-    @task_name    = 'command_with_args_and_defaults'
-
-    validation_string = random_string
-    argument_validation_string = random_string
+  step 'Add Command argument with block syntax and unset override_env' do
+    argument_override_env2 = unique_env_on(sut)
+    argument_env_value2 = "ENV_VALUE#{random_string}"
+    default_arg2        = 'HANKVENTURE'
+    task_name2          = 'command_with_args_and_defaults2'
 
     rakefile_contents = <<-EOS
 #{rototiller_rakefile_header}
-rototiller_task :#{@task_name} do |t|
+rototiller_task :#{task_name2} do |t|
     t.add_command do |c|
-      c.name = 'echo #{validation_string}'
-      c.override_env = '#{override_env}'
-      c.argument = '#{argument_validation_string}'
-      c.argument_override_env = '#{override_env}'
+      c.name = 'echo'
+      c.argument = '#{default_arg2}'
+      c.argument_override_env = '#{argument_override_env2}'
     end
 end
     EOS
     rakefile_path = create_rakefile_on(sut, rakefile_contents)
 
-    execute_task_on(sut, @task_name, rakefile_path) do |result|
-      command_regex = /#{validation_string} #{argument_validation_string}/
+    execute_task_on(sut, task_name2, rakefile_path) do |result|
+      command_regex = /^#{argument_env_value2}/
       assert_match(command_regex, result.stdout, 'The correct command was not observed')
     end
   end

--- a/lib/rototiller/task/block_handling.rb
+++ b/lib/rototiller/task/block_handling.rb
@@ -5,7 +5,14 @@ module Rototiller
       class BlockSyntax
 
         def initialize(param_array)
-          self.class.class_eval { param_array.each { |i| attr_accessor i } }
+          self.class.class_eval { param_array.each do |i|
+            # define attribute setters for each param array. these are used
+            attr_writer   i
+            # define attribute getters with arguments for the nested attributes of the same name who receive args as hashes
+            #   these will not be used as the hash args are stripped off when we yield to the parent (caller)
+            define_method("#{i}") { |arg = nil| }
+          end
+          }
         end
 
         def to_h

--- a/lib/rototiller/task/collections/env_collection.rb
+++ b/lib/rototiller/task/collections/env_collection.rb
@@ -5,9 +5,20 @@ module Rototiller
   module Task
 
     class EnvCollection < ParamCollection
+
       def allowed_class
         EnvVar
       end
+
+      # remove the nils and return the last known value
+      def last
+        if self.any?
+          last_known_env_var = self.map{|x| x.value}.compact.last
+          # ruby converts nil to "", so guard against single non-set env vars here
+          last_known_env_var.to_s if last_known_env_var
+        end
+      end
+
     end
 
   end

--- a/lib/rototiller/task/collections/param_collection.rb
+++ b/lib/rototiller/task/collections/param_collection.rb
@@ -7,7 +7,7 @@ module Rototiller
 
       extend Forwardable
 
-      def_delegators :@collection, :clear, :delete_if, :include?, :include, :inspect, :each, :[], :map
+      def_delegators :@collection, :clear, :delete_if, :include?, :include, :inspect, :each, :[], :map, :any?, :compact
 
       # collect a given task's params
       def initialize

--- a/lib/rototiller/task/collections/param_collection.rb
+++ b/lib/rototiller/task/collections/param_collection.rb
@@ -36,6 +36,14 @@ module Rototiller
         formatted_message
       end
 
+      # Do any of the contents of this ParamCollection require the task to stop
+      # @return [true, nil] should the values of this ParamCollection stop the task
+      def stop?
+        @collection.any?{ |param| param.stop }
+      end
+
+      private
+
       #@private
       def filter_contents(filters={})
 
@@ -69,13 +77,6 @@ module Rototiller
         end
       end
 
-      # Do any of the contents of this ParamCollection require the task to stop
-      # @return [true, nil] should the values of this ParamCollection stop the task
-      def stop?
-        @collection.any?{ |param| param.stop }
-      end
-
-      private :filter_contents, :check_classes
     end
 
   end

--- a/lib/rototiller/task/params/command.rb
+++ b/lib/rototiller/task/params/command.rb
@@ -6,6 +6,15 @@ require 'rototiller/task/block_handling'
 module Rototiller
   module Task
 
+    # The Command class to implement rototiller command handling
+    #   via a RototillerTask's #add_command
+    # @since v0.1.0
+    # @attr [String] name The name of the command to run
+    # @attr_reader [Struct] result A structured command result
+    #    contains members: output, exit_code and pid (from Open3.popen2e)
+    # @attr [String] argument Command argument (this will change to add_argument in the next release)
+    # @attr [String] argument_override_env The environment variable (if any) users can employ to override the above argument
+    #    (this will change to Argument's #add_env in the next release)
     class Command < RototillerParam
       include Rototiller::ColorText
       include BlockHandling
@@ -56,6 +65,35 @@ module Rototiller
         else
           @argument = attribute_hash[:argument]
         end
+
+      end
+
+      # adds environment variables to be tracked, messaged.
+      #   In the Command context this env_var overrides the command "name"
+      # @param [Hash] args hashes of information about the environment variable
+      # @option args [String] :name The environment variable
+      # @option args [String] :default The default value for the environment variable
+      # @option args [String] :message A message describing the use of this variable
+      #
+      # for block {|a| ... }
+      # @yield [a] Optional block syntax allows you to specify information about the environment variable, available methods match hash keys
+      def add_env(*args, &block)
+        raise ArgumentError.new("#{__method__} takes a block or a hash") if !args.empty? && block_given?
+        # this is kinda annoying we have to do this for all params? (not DRY)
+        #   have to do it this way so EnvVar doesn't become a collection
+        #   but if this gets moved to a mixin, it might be more tolerable
+        if block_given?
+          @env_vars.push(EnvVar.new(&block))
+        else
+          #TODO: test this with array and non-array single hash
+          args.each do |arg| # we can accept an array of hashes, each of which defines a param
+            error_string = "#{__method__} takes an Array of Hashes. Received Array of: '#{arg.class}'"
+            raise ArgumentError.new(error_string) unless arg.is_a?(Hash)
+            @env_vars.push(EnvVar.new(arg))
+          end
+        end
+        # remove the nils and return the last known value
+        @name = @env_vars.map{|x| x.value}.compact.last.to_s if @env_vars.any?
       end
 
       # convert a Command object to a string (runable command string)

--- a/lib/rototiller/task/params/command.rb
+++ b/lib/rototiller/task/params/command.rb
@@ -1,6 +1,5 @@
 require 'open3'
-require 'rototiller/task/params'
-require 'rototiller/task/params/env_var'
+require 'rototiller/task/collections/env_collection'
 require 'rototiller/task/block_handling'
 
 module Rototiller
@@ -25,9 +24,6 @@ module Rototiller
       # @return [Struct] the command results, if run
       attr_reader :result
 
-      # @return [EnvVar] the ENV that is equal to this command
-      attr_accessor :override_env
-
       # @return [String, nil] the value that should be used as an argument to the given command
       attr_accessor :argument
 
@@ -40,22 +36,22 @@ module Rototiller
       # @yield Command object with attributes matching method calls supported by Command
       # @return Command object
       def initialize(args={}, &block)
+        # the env_vars that override the command name
+        @env_vars      = EnvCollection.new
+
         if block_given?
-          required_attributes = [:name, :override_env, :argument, :argument_override_env]
-          attribute_hash = pull_params_from_block(required_attributes, &block)
+          allowed_attributes = [:name, :add_env, :argument, :argument_override_env]
+          attribute_hash = pull_params_from_block(allowed_attributes, &block)
+          yield self
         else
           attribute_hash = args
         end
-        # TODO: make this a global options hash?
-        #   no, needs to be per-param with a default to false except in task's env_var, the other env_vars should not pollute the environment space
-        #attribute_hash[:set_env] = true if opts[:set_env]
 
-        # check if an override_env is provided
-        if attribute_hash[:override_env]
-          @override_env = EnvVar.new({:name => attribute_hash[:override_env], :default => attribute_hash[:name]})
-          @name = @override_env.value
-        else
-          @name = attribute_hash[:name]
+        #hmmmm... maybe we really should convert to block and then yield on self?
+        # on the otherhand, there shouldn't be many of these and we can just loop over allowed_attributes
+        @name = @env_vars.last || attribute_hash[:name]
+        if attribute_hash[:add_env]
+          add_env(attribute_hash[:add_env])
         end
 
         # check if an argument_override_env is provided
@@ -92,8 +88,7 @@ module Rototiller
             @env_vars.push(EnvVar.new(arg))
           end
         end
-        # remove the nils and return the last known value
-        @name = @env_vars.map{|x| x.value}.compact.last.to_s if @env_vars.any?
+        @name = @env_vars.last if @env_vars.last
       end
 
       # convert a Command object to a string (runable command string)

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -5,13 +5,16 @@ require 'rake/tasklib'
 module Rototiller
   module Task
 
+    # The main task type to implement base rototiller features in a Rake task
+    # @since v0.1.0
+    # @attr_reader [String] name The name of the task for calling via Rake
+    # @attr [Boolean] fail_on_error Whether or not to fail Rake when an error
+    #   occurs (typically when examples fail). Defaults to `true`.
+    # @attr [String] failure_message A message to print to stderr when there are failures.
     class RototillerTask < ::Rake::TaskLib
       attr_reader :name
-      # Whether or not to fail Rake when an error occurs (typically when
-      # examples fail). Defaults to `true`.
       # FIXME: make fail_on_error per-command
       attr_accessor :fail_on_error
-      # A message to print to stderr when there are failures.
       # FIXME: make this per-command
       attr_accessor :failure_message
 

--- a/lib/rototiller/task/rototiller_task.rb
+++ b/lib/rototiller/task/rototiller_task.rb
@@ -72,14 +72,19 @@ module Rototiller
       def add_command(*args, &block)
         raise ArgumentError.new("#{__method__} takes a block or a hash") if !args.empty? && block_given?
         if block_given?
-          @commands.push(Command.new(&block))
+          new_command = Command.new(&block)
+          @commands.push(new_command)
         else
           args.each do |arg| # we can accept an array of hashes, each of which defines a param
             error_string = "#{__method__} takes an Array of Hashes. Received Array of: '#{arg.class}'"
             raise ArgumentError.new(error_string) unless arg.is_a?(Hash)
-            @commands.push(Command.new(arg))
+            new_command = Command.new(arg)
+            @commands.push(new_command)
           end
         end
+        # because add_command is at the top of the hierarchy chain, it has to return its produced object
+        #   otherwise we yield on the blocks inside and don't have add_env that can handle an Array of hashes.
+        return new_command
       end
 
 

--- a/spec/rototiller/task/block_handling_spec.rb
+++ b/spec/rototiller/task/block_handling_spec.rb
@@ -55,6 +55,28 @@ shared_examples_for Rototiller::Task::BlockHandling do
       expect(@obj.pull_params_from_block(params,&block)).to raise_error(NameError)
     end
 
+    context 'nested block handling should be ignored' do
+      it 'should handle blocks with nested blocks' do
+        block = Proc.new do |b|
+          b.name = 'value'
+          b.other { |x| x.something }
+        end
+        expected_hash = {:name=>"value", :other=>nil}
+        params = expected_hash.keys
+        final_expected = {:name => 'value'}
+        expect(@obj.pull_params_from_block(params,&block)).to eq final_expected
+      end
+      it 'should handle blocks with nested hashes' do
+        block = Proc.new do |b|
+          b.name = 'value'
+          b.other({ :name => 'something' })
+        end
+        expected_hash = {:name=>"value", :other=>nil}
+        params = expected_hash.keys
+        final_expected = {:name => 'value'}
+        expect(@obj.pull_params_from_block(params,&block)).to eq final_expected
+      end
+    end
   end
 
 end

--- a/spec/rototiller/task/collections/env_collection_spec.rb
+++ b/spec/rototiller/task/collections/env_collection_spec.rb
@@ -9,6 +9,48 @@ module Rototiller
           expect( described_class.new.allowed_class ).to eql(EnvVar)
         end
       end
+
+      context '#last' do
+        let(:collection) { described_class.new }
+        it 'returns nil when collection empty' do
+          expect(collection.last).to be_nil
+        end
+        it 'returns nil when solitary EnvVar is empty' do
+          allow(ENV).to receive(:[]).with('BLAH').and_return(nil)
+          collection.push EnvVar.new({:name => 'BLAH'})
+          expect(collection.last).to be_nil
+        end
+        it 'returns nil when two EnvVars are empty' do
+          allow(ENV).to receive(:[]).with('BLAH').and_return(nil)
+          allow(ENV).to receive(:[]).with('BLAH2').and_return(nil)
+          collection.push EnvVar.new({:name => 'BLAH'})
+          collection.push EnvVar.new({:name => 'BLAH2'})
+          expect(collection.last).to be_nil
+        end
+        it 'returns value when solitary EnvVar has a value' do
+          allow(ENV).to receive(:[]).with('BLAH').and_return('success')
+          collection.push EnvVar.new({:name => 'BLAH'})
+          expect(collection.last).to eq 'success'
+        end
+        it 'returns value when first EnvVar has value and rest empty' do
+          allow(ENV).to receive(:[]).with('BLAH').and_return('success')
+          allow(ENV).to receive(:[]).with('BLAH2').and_return(nil)
+          collection.push EnvVar.new({:name => 'BLAH'})
+          collection.push EnvVar.new({:name => 'BLAH2'})
+          expect(collection.last).to eq 'success'
+        end
+        it 'returns correct value when multiple nil and EnvVars exist' do
+          allow(ENV).to receive(:[]).with('BLAH').and_return('fail')
+          allow(ENV).to receive(:[]).with('BLAH2').and_return(nil)
+          allow(ENV).to receive(:[]).with('BLAH3').and_return('success')
+          allow(ENV).to receive(:[]).with('BLAH4').and_return(nil)
+          collection.push EnvVar.new({:name => 'BLAH'})
+          collection.push EnvVar.new({:name => 'BLAH2'})
+          collection.push EnvVar.new({:name => 'BLAH3'})
+          collection.push EnvVar.new({:name => 'BLAH4'})
+          expect(collection.last).to eq 'success'
+        end
+      end
     end
 
   end

--- a/spec/rototiller/task/collections/param_collection_spec.rb
+++ b/spec/rototiller/task/collections/param_collection_spec.rb
@@ -51,7 +51,7 @@ module Rototiller
           messages = param_collection.format_messages
 
           vars.each do |var|
-            expect(messages).to match(/#{var.var}/)
+            expect(messages).to match(/#{var.name}/)
           end
         end
 
@@ -60,7 +60,7 @@ module Rototiller
           param_collection.push(*vars)
 
           [unset_env_1_no_default, unset_env_2_no_default].each do |var|
-            expected_message = /31mERROR: #{env_message_header} '#{var.var}' is required: description/
+            expected_message = /31mERROR: #{env_message_header} '#{var.name}' is required: description/
             expect(param_collection.format_messages({:stop => true})).to match(expected_message)
           end
         end
@@ -69,7 +69,7 @@ module Rototiller
           param_collection.push(*vars)
 
           [set_env_1_no_default, set_env_2_no_default].each do |var|
-            expected_message = /32mINFO: #{env_message_header} '#{var.var}' was found with value: '#{ENV[var.var]}'/
+            expected_message = /32mINFO: #{env_message_header} '#{var.name}' was found with value: '#{ENV[var.name]}'/
             expect(param_collection.format_messages({:default => nil, :message_level => :info})).to match(expected_message)
           end
         end

--- a/spec/rototiller/task/params/env_var_spec.rb
+++ b/spec/rototiller/task/params/env_var_spec.rb
@@ -52,7 +52,7 @@ module Rototiller
               describe '.var' do
 
                 it 'returns the var' do
-                  expect(@env_var.var).to eq(@var_name)
+                  expect(@env_var.name).to eq(@var_name)
                 end
               end
 


### PR DESCRIPTION
- add #add_env to command
- it will overwrite command name with its value
- FIXME: we mainly duplicate add_env here from rototiller_task, it can
  be put in a module
- add #to_str for EnvVar so it can be printed and find its value
- add #last to env_collection so one can easily find the last known
  value of a collection of EnvVars.
- block_handling needed empty methods defined for nested blocks and
  hashes. When a Command is created and has a nested add_env, for
  instance, the add_env must be both a setter and a method (getter), even
  though it is not actually called.
- ensure we return the EnvVar or Command when using #add_env or
  #add_command
- EnvVar (and other params) need their attribute names to match their
  allowed attributes because we now must yield using EnvVar objects, so
  the blocks populate the actual EnvVar
  ee96188  
