### PR TITLE
(maint) fixup doc problems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,25 @@
 * Yard docs are great for other developers, but often are difficult to read for users. If your change impacts user-facing functionality, please include changes to the human-readable markdown docs starting at README.md
 * During the time that you are working on your patch the master Rototiller branch may have changed - you'll want to [rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) before you submit your PR with `git rebase master`.  A successful rebase ensures that your patch will cleanly merge into Rototiller.
 * Submitted patches will be smoke tested through a series of acceptance level tests that ensures basic Rototiller functionality - the results of these tests will be evaluated by a Rototiller team member.  Failures associated with the submitted patch will result in the patch being rejected.
-* Rototiller's Architecture:
-![Rototiller's Architecture](doc/rototiller_class_graph.png)
+
+## Submitting Changes
+
+* Sign the [Contributor License Agreement](http://links.puppet.com/cla).
+* Push your changes to a topic branch in _your_ fork of the repository.
+* Submit a pull request to [Rototiller](https://github.com/puppetlabs/rototiller)
+* PRs are reviewed as time permits.
+
+# Additional Resources
+
+* [Rototiller's Yard Docs](http://www.rubydoc.info/github/puppetlabs/rototiller) (API/internal Architecture docs)
+* [Rototiller's Architecture](docs/rototiller_class_graph.png)
+* [More information on contributing](http://links.puppet.com/contribute-to-puppet)
+* [Contributor License Agreement](http://links.puppet.com/cla)
+* [General GitHub documentation](http://help.github.com/)
+* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+* Questions?  Comments?  Contact the Rototiller team at qa-team@puppet.com
+  * The keyword `rototiller` is monitored and we'll get back to you as quick as we can.
+* Rototiller's Architecture: [Rototiller's Architecture](docs/rototiller_class_graph.png)
 
 ## Submitting Changes
 

--- a/README.md
+++ b/README.md
@@ -74,150 +74,16 @@ this does, _mostly_ the same as below.  but what do the various environment vari
 * [rototiller\_task reference](docs/rototiller_task_reference.md)
   * contains usage information on all rototiller_task API methods
 
-## Issues
-
-* none. it's perfect, but just in case (sorry, this is Puppet-internal for now)
-* [Jira: Rototiller](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20QA)
-* [Puppet QA-team](mailto:qa-team@puppet.com)
-
 ## More Documentation
 
 Rototiller is documented using yard
-to view yard docs, including internal Classes and Modules:
-
-First build a local copy of the gem
-
-    $) bundle exec rake build
-
-Next start the yard server
-
-    $) bundle exec yard server
-
-Finally navigate to http://0.0.0.0:8808/ to view the documentation
+* [Rototiller's Yard Docs](http://www.rubydoc.info/github/puppetlabs/rototiller) (API/internal Architecture docs)
 
 ## Contributing
 * [Contributing](CONTRIBUTING.md)
 
-## abandon hope, all ye who enter here
-### All permutations of v2 API (remove and refactor into useful doc sections below upon testing, merge-up to stable)
+## Issues
 
-* all things that can take multiples should use add\_ as precursor to method name
-* all things that only take one should use set\_ as precursor to method name?
-    require 'rototiller'
-
-    ## all task methods
-    rototiller_task :name do |t|
-      t.add_command # t.add_cmd? me no likey
-      t.add_env
-    end
-    rototiller_task do |t|
-      t.set_name = 'string_name' # should this be validated??  e.g.: spaces, etc
-      t.add_command
-      t.add_env
-    end
-
-
-    ## all task's add_env invocations with just name
-    t.add_env('env_name') #required, default messaging
-    t.add_env :env_name
-    t.add_env 'env_name' # implicitly allowed by ruby
-    t.add_env do |e|
-      e.name
-    end
-
-    ## all task's add_env invocations with name, message
-    #t.add_env('env_name')  # impossible
-    t.add_env :env_name do |e|
-    t.add_env 'env_name' do |e|  # should we do this too?
-      e.set_message
-    end
-    t.add_env do |e|
-      e.name
-      e.message
-    end
-
-    ## all task's add_env invocations with name, value
-    #t.add_env('env_name')  # impossible
-    t.add_env :env_name do |e|
-    t.add_env 'env_name' do |e|  # should we do this too?
-      e.default/value  # does value imply the env will be set by rototiller?  does default NOT?
-    end
-    t.add_env do |e|
-      e.name
-      e.default/value
-    end
-
-    ## all task's add_env invocations with name, value, message
-    #t.add_env('env_name')  # impossible
-    t.add_env :env_name do |e|
-      e.default/value  # does value imply the env will be set by rototiller?  does default NOT?
-      e.message
-    end
-    t.add_env do |e|
-      e.name
-      e.default/value
-      e.message
-    end
-
-
-    ## all task's add_command invocations with only name
-    # default messaging, no env override?
-    t.add_command('echo --blah my name is ray')
-    t.add_command :echo
-    t.add_command 'echo'
-    t.add_command do |c|
-      c.name = 'echo'
-    end
-
-    ## all task's add_command invocations with name (string), message
-    #t.add_command('echo --blah my name is ray', 'message') # ArgumentError
-    t.add_command :echo
-    t.add_command 'echo' do |c|
-      c.name = 'echo' # # nomethod error?
-      c.message = 'why we echo'
-    end
-    t.add_command do |c|
-      c.name = 'echo'
-      c.message = 'blah'
-    end
-
-    ## all task's add_command invocations with name (block) (could be same for message?)
-    #t.add_command('echo --blah my name is ray', 'message') # ArgumentError
-    #t.add_command :echo
-    #t.add_command 'echo' do |c|
-    #  c.message = 'blah'
-    #end
-    t.add_command do |c|
-      c.name 'echo' do |n|
-        n.add_env
-      end
-      c.add_arg 'some_arg' do |a|
-        a.add_env
-        a.message
-      end
-      c.add_option '--option_name' do |o|
-        o.add_arg 'switch_arg' do |a|
-          a.add_env 'opion-arg_env' do |e|
-            e.set_name
-            e.set_message
-            e.set_value
-          end
-        end
-        o.add_env 'option-name_env' do |e|
-          e.set_name
-          e.set_message
-          e.set_value
-        end
-        o.message
-      end
-      c.add_switch '--some_switch' do |s|
-        s.add_env 'env_name' do |e|
-          e.set_name
-          e.set_message
-          e.set_value
-        end
-        s.message
-      end
-    end
-
-    #should we be able to add an env for any given message?  i don't see a use case, we should probably just save users from themselves here.
+* none. it's perfect, but just in case:
+  * [Jira: Rototiller](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20QA) (sorry, this is Puppet-internal for now)
+  * [Puppet QA-team](mailto:qa-team@puppet.com)

--- a/docs/rototiller_task_reference.md
+++ b/docs/rototiller_task_reference.md
@@ -1,33 +1,25 @@
 # Rototiller Task Reference
 * herein lies the reference to the rototiller_task API
 
-* [#rototiller_task](#rototiller_task)
-  * [#add_command](#rototiller_task:add_command)
-  * [#add_env](#rototiller_task:add_env)
-  * [Command](#Command)
-    * [#add\_env](#Command:add_env)
-    * [#add\_switch](#Command:add_switch)
-      * [#add\_env](#Command:add_switch:add_env)
-    * [#add\_option](#Command:add_option)
-      * [#add\_env](#Command:add_option:add_env)
-      * [#add\_argument](#Command:add_option:add_argument)
-        * [#add\_env](#Command:add_option:add_argument:add_env)
-    * [#add\_argument](#Command:add_argument)
-      * [#add\_env](#Command:add_argument:add_env)
+* [rototiller_task](rototiller_task)
+  * [#add_env](rototiller_task-add_env)
+  * [#add_command](rototiller_task-add_command)
+  * [Command](Command)
+    * [#add\_env](Command-add_env)
+    * [#add\_switch](Command-add_switch)
+      * [#add\_env](Command-add_switch-add_env)
+    * [#add\_option](Command-add_option)
+      * [#add\_env](Command-add_option-add_env)
+      * [#add\_argument](Command-add_option-add_argument)
+        * [#add\_env](Command-add_option-add_argument-add_env)
+    * [#add\_argument](Command-add_argument)
+      * [#add\_env](Command-add_argument-add_env)
 
 <a name="rototiller_task"></a>
-## #rototiller_task
+## rototiller_task
 * behaves just like any other rake task name (see below)
 
-<a name="rototiller_task:add_command"></a>
-### #add_command
-* adds a command to a rototiller_task. This command can in turn contain environment variables, switches, options and arguments
-* this command (and any others) will be run with the task is executed
-* (!) currently a task will fail if its command fails _only_ if `#fail_on_error` is set
-  * the error message from the command will only be shown when rake is run with `--verbose`
-  * this will be fixed post-1.0
-
-<a name="rototiller_task:add_env"></a>
+<a name="rototiller_task-add_env"></a>
 ### #add_env
 * parent methods such as `add_command`, `add_argument`, `add_switch`, and  `add_option` can utilize the method `add_env` to add an env to a param
 * adds an arbitrary environment variable for use in the task
@@ -35,20 +27,25 @@
 * If the parent does not call the `name=` method and the method `default=` is called under `add_env` the value passed to `default=` is the default
 * If the parent does not call the `name=` method and the method `name=` is called under `add_env` the task will only continue if a value is found in the environment
 * if specified with a default value, and the system environment does not have this variable set, rototiller will set it, for later use in a task or otherwise
-* the same method can be used for any portion of a [command](#Command:add_env) as well, including command name, options, option arguments, switches, and command arguments.  In these cases the environment variable's value will override that portion of the command string.
+* the same method can be used for any portion of a [command](#Command-add_env) as well, including command name, options, option arguments, switches, and command arguments.  In these cases the environment variable's value will override that portion of the command string.
 * more add_env use cases can be seen in the [env\_var\_example\_reference](env_var_example_reference.md)
 
-| Environment Variable and Task/Command Interactions |
+#### Environment Variable and Task/Command Interactions
+
 | has default?  | exists in ENV? | rototiller creates | rototiller stops |
 | ------------  | -------------- | ------------------ | ---------------- |
 |      n        |       n        |        n           |         y        |
-| ------------  | -------------- | ------------------ | ---------------- |
 |      n        |       y        |        n           |         n        |
-| ------------  | -------------- | ------------------ | ---------------- |
 |      y        |       n        |        y           |         n        |
-| ------------  | -------------- | ------------------ | ---------------- |
 |      y        |       y        |        n           |         n        |
 
+<a name="rototiller_task-add_command"></a>
+### #add_command
+* adds a command to a rototiller_task. This command can in turn contain environment variables, switches, options and arguments
+* this command (and any others) will be run with the task is executed
+* (!) currently a task will fail if its command fails _only_ if `#fail_on_error` is set
+  * the error message from the command will only be shown when rake is run with `--verbose`
+  * this will be fixed post-1.0
 
 &nbsp;
 
@@ -83,7 +80,7 @@ produces:
 
 <a name="Command"></a>
 ## Command
-<a name="Command:add_env"></a>
+<a name="Command-add_env"></a>
 ### #add_env
 * adds an arbitrary environment variable which overrides the name of the command
 * if specified with a default value, and the system environment does not have this variable set, rototiller will set it, for later use in a task or otherwise
@@ -130,36 +127,36 @@ produces:
     partial success
     awwww yeah!
 
-<a name="Command:add_switch"></a>
+<a name="Command-add_switch"></a>
 ### #add_switch
-<a name="Command:add_argument"></a>
+<a name="Command-add_argument"></a>
 ### #add_argument
 * adds an arbitrary string to a command
   * intended to add `--switch` type binary switches that do not take arguments (see [add_option](#Command:add_option))
   * add\_argument is intended to add strings to the end of the command string (options and switches are added prior to arguments
 
-<a name="Command:add_switch:add_env"></a>
-<a name="Command:add_argument:add_env"></a>
+<a name="Command-add_switch-add_env"></a>
+<a name="Command-add_argument-add_env"></a>
 #### #add_env
 * just like the other `#add_env` methods for other portions of a Command
 * adds an arbitrary environment variable which overrides the name of the switch or argument
 * if specified with a default value, and the system environment does not have this variable set, rototiller will set it, for later use in a task or otherwise
 * more add_env use cases can be seen in the [env\_var\_example\_reference](env_var_example_reference.md)
 
-<a name="Command:add_option"></a>
+<a name="Command-add_option"></a>
 ### #add_option
 
-<a name="Command:add_option:add_env"></a>
+<a name="Command-add_option-add_env"></a>
 #### #add_env
 * adds an arbitrary environment variable which overrides the name of the option (usually the thing with the --)
 * just like the other `#add_env` methods for other portions of a Command
 * more add_env use cases can be seen in the [env\_var\_example\_reference](env_var_example_reference.md)
 
-<a name="Command:add_option:add_argument"></a>
+<a name="Command-add_option-add_argument"></a>
 #### #add_argument
 * adds an arbitrary string to trail an option (aka: an option argument)
 
-<a name="Command:add_option:add_argument:add_env"></a>
+<a name="Command-add_option-add_argument-add_env"></a>
 ##### #add_env
 * adds an arbitrary environment variable which overrides the name of _argument_ of this option
 * just like the other `#add_env` methods for other portions of a Command


### PR DESCRIPTION
* old docs from pre-1.0 left hanging around, now removed
* remove spurious process for creating yard server
  * point to rubydoc.org instead
* fix reference doc table in GH markdown
* fix reference doc TOC links