### PR TITLE
(QA-2887) Rototiller should not depend on Rake 11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,11 @@ def location_for(place, fake_version = nil)
 end
 
 # in the Rakefile, so we require it in all groups
-rake_version = ENV['RAKE_VER'] || '11.0'
-gem 'rake'                 , "~> #{rake_version}"
+rake_version = '>= 0.9.0'
+if ENV['RAKE_VER']
+  rake_version = "~> #{ENV['RAKE_VER']}"
+end
+gem 'rake'                 , "#{rake_version}"
 gem "rototiller", *location_for(ENV['TILLER_VERSION'] || '~> 0.1.0')
 gem 'rspec'                ,'~> 3.4.0'
 


### PR DESCRIPTION
* previously the gemfile would require ~> 11.0 if no env was set
* this causes problems with beaker who requires ~>10.0
* set to anything greater/equal than 0.9.0 unless the env is used