### PR TITLE
DO NOT MERGE (QA-2851) Pry not functional during Rototiller task

### DIFF
--- a/spec/rototiller/task/params/command_spec.rb
+++ b/spec/rototiller/task/params/command_spec.rb
@@ -52,18 +52,18 @@ module Rototiller
         end
         it 'has results after successful run' do
           command.run
-          expect( command.result.output.strip ).to eq(@arg_name)
+          expect( command.result.output.strip ).to eq('')
           expect( command.result.exit_code ).to eq(0)
         end
         it 'has results after failed run' do
           command.name = 'doesnotexist'
           command.run
-          expect( command.result.output.strip ).to match(/sh\: .*doesnotexist\: (command )?not found/)
+          expect( command.result.output.strip ).to match(/doesnotexist\: command not found/)
           expect([2,127]).to include(command.result.exit_code)
         end
         context 'with a block' do
           it 'runs the block' do
-            expect{ command.run { |result| puts "my exit_code: '#{result.exit_code}'" } }.to output("#{@arg_name}\nmy exit_code: '0'\n").to_stdout
+            expect{ command.run { |result| puts "my exit_code: '#{result.exit_code}'" } }.to output("my exit_code: '0'\n").to_stdout
           end
         end
       end

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -163,7 +163,7 @@ module Rototiller::Task
             end
             expect(task).to receive(:exit)
             expect{ described_run_task }
-              .to output(/my_shiny_new_command:( command)? not found/)
+              .to output(/my_shiny_new_command/)
               .to_stdout
           end
           it 'can override command name with env_var in block as hash' do
@@ -178,7 +178,7 @@ module Rototiller::Task
             # not sure why this is calling exit twice
             expect(task).to receive(:exit)
             expect{ described_run_task }
-              .to output(/my_shiny_new_command:( command)? not found/)
+              .to output(/my_shiny_new_command/)
               .to_stdout
           end
           it 'raises an error when supplied a bad key' do

--- a/spec/rototiller/task/rototiller_task_spec.rb
+++ b/spec/rototiller/task/rototiller_task_spec.rb
@@ -116,7 +116,12 @@ module Rototiller::Task
           task.__send__(:set_verbose,verbose)
         end
         it 'prints command failed' do
-          expect(task).to receive(:exit).with(2)
+          # argh!  (facepalm)         +          expect(task).to receive(:exit).with(2)
+          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+            expect(task).to receive(:exit).with(127)
+          else
+            expect(task).to receive(:exit).with(2)
+          end
 
           #FIXME: despite the silence_output some of these are spewing
           #  this is because we set command to "echo empty RototillerTask. You should define a command, send a block, or EnvVar to track."


### PR DESCRIPTION
* open3, Kernel#`, et al do not allow interaction with the subprocess
* this prevents pry and the like in the subprocess started from rototiller
* we change to using Kerne#system here
  ** that results in no output stream for saving
  ** we do still have pid and exit_code
* this is a breaking change due to the output stream issue
* we should look into other methods using pipes to try and save the output stream

this needs more work, i'm hoping sam comes up with a solution using pipes that allows capture of the output streams
and it's blocked as we have to update master's version string to 2.0.0