### PR TITLE
(QA-2851) Fix missing pry prompts and extra newlines in stdout

### DIFF
--- a/lib/rototiller/task/params/command.rb
+++ b/lib/rototiller/task/params/command.rb
@@ -181,7 +181,6 @@ module Rototiller
 
         #FIXME: monitor for deadlock?
         while @exitstatus == :not_done
-          sleep 0.001
           begin
             # readpartial will read UP to amount given
             # we should never really need 64k, but it makes the responsiveness
@@ -192,7 +191,9 @@ module Rototiller
             next
           end
           @result.output << this_read
-          puts this_read
+          $stdout.sync = true # print stuff right away
+          print this_read
+          sleep 0.001
         end
 
         if block_given? # if block, send result to the block


### PR DESCRIPTION
* the previous fix to this ticket used `puts` to print the output stream.
puts tacks newlines on the end of each string. print does not.
* we also move the sleep to the end of the loop so it prints asap.
* `$stdout.sync` addition allows the pry prompt to show up as it syncs
the buffers before there is user interaction.