### PR TITLE
(maint) pin beaker to 3.0 for ruby 2.1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,11 @@ group :system_tests do
   # restrict gems to enable ruby versions
   #
   #   nokogiri comes along for the ride but needs some restriction too
-  if Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new('2.0.0'),Gem::Version.new('2.2.4'))
+  if Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new('2.1.6'),Gem::Version.new('2.2.4'))
     beaker_version   = '<  3.9.0'
+    nokogiri_version = '<  1.7.0'
+  elsif Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new('2.0.0'),Gem::Version.new('2.1.5'))
+    beaker_version   = '<  3.1.0'
     nokogiri_version = '<  1.7.0'
   elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
     beaker_version   = '~> 2.0'

--- a/lib/rototiller/version.rb
+++ b/lib/rototiller/version.rb
@@ -1,5 +1,5 @@
 module Rototiller
   module Version
-    STRING = '1.0.1'
+    STRING = '1.0.2'
   end
 end


### PR DESCRIPTION
master acceptance is failing
* some of our testrunners are still on ruby 2.1.5
* beaker 3.1+ requires ruby 2.2.5