### PR TITLE
(qa-3114) update Rakefile to rototiller 1.y

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 # unit tests: --without system_tests development
 gem 'rake'
-gem "rototiller", *location_for(ENV['TILLER_VERSION'] || '~> 0.1.0')
+gem "rototiller", *location_for(ENV['TILLER_VERSION'] || '~> 1.0')
 gem 'rspec'                  ,'~> 3.4.0'
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :system_tests do
   end
   gem 'beaker'               ,"#{beaker_version}"
   gem 'beaker-hostgenerator'
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
   gem 'nokogiri'             ,"#{nokogiri_version}"
   gem 'public_suffix'        ,"#{public_suffix_version}"
   gem 'activesupport'        ,"#{activesupport_version}"

--- a/Rakefile
+++ b/Rakefile
@@ -6,80 +6,84 @@ task :default do
   sh %{rake -T}
 end
 
-desc "Run spec tests"
-RSpec::Core::RakeTask.new(:test) do |t|
-  t.rspec_opts = ['--color']
-  t.pattern = ENV['SPEC_PATTERN']
+namespace :test do
+
+  desc "Run unit tests"
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.rspec_opts = ['--color']
+    t.pattern = ENV['SPEC_PATTERN']
+  end
+
+  task :test => [:check_test]
+
+  task :generate_host_config do |t, args|
+
+    target = ENV["LAYOUT"] || ENV["TEST_TARGET"] || 'centos7-64'
+    generate = "beaker-hostgenerator"
+    generate += " #{target}"
+    generate += " > acceptance/hosts.cfg"
+    sh generate
+    sh "cat acceptance/hosts.cfg"
+  end
+
+  default_rake_ver = '11.0'
+
+  desc "Run acceptance tests"
+  rototiller_task :acceptance => [:generate_host_config] do |t|
+    t.add_env({:name => 'LAYOUT',   :default => 'centos7-64',
+               :message => 'The argument to pass to beaker-hostgenerator',
+               :set_env => true})
+    t.add_env({:name => 'RAKE_VER', :default => default_rake_ver,
+               :message => 'The rake version to use when running unit and acceptance tests',
+               :set_env => true})
+
+    t.add_flag do |flag|
+      flag.name = '--hosts'
+      flag.default = 'acceptance/hosts.cfg'
+      flag.message = 'The configuration file that Beaker will use'
+      flag.override_env = 'BEAKER_HOSTS'
+    end
+    t.add_flag do |flag|
+      flag.name = '--preserve-hosts'
+      flag.default = 'onfail'
+      flag.message = 'The beaker setting to preserve a provisioned host'
+      flag.override_env = 'BEAKER_PRESERVE_HOSTS'
+    end
+    t.add_flag do |flag|
+      flag.name = '--keyfile'
+      flag.default ="#{ENV['HOME']}/.ssh/id_rsa-acceptance"
+      flag.message = 'The SSH key used to access a SUT'
+      flag.override_env = 'BEAKER_KEYFILE'
+    end
+    t.add_flag do |flag|
+      flag.name = '--load-path'
+      flag.default = 'acceptance/lib'
+      flag.message = 'The load path Beaker will use'
+      flag.override_env = "BEAKER_LOAD-PATH"
+    end
+    t.add_flag do |flag|
+      flag.name = '--pre-suite'
+      flag.default = 'acceptance/pre-suite'
+      flag.message = 'THe path to a directory containing pre-suites'
+      flag.override_env = "BEAKER_PRE-SUITE"
+    end
+    t.add_flag do |flag|
+      flag.name = '--tests'
+      flag.default = 'acceptance/tests'
+      flag.message = 'The path to the tests you want beaker to run'
+      flag.override_env = 'BEAKER_TESTS'
+    end
+
+    t.add_command({:name => 'beaker --debug --no-ntp --repo-proxy --no-validate', :override_env => 'BEAKER_EXECUTABLE'})
+  end
+
+  desc ""
+  rototiller_task :check_test do |t|
+    t.add_env({:name => 'SPEC_PATTERN', :default => 'spec/', :message => 'The pattern RSpec will use to find tests', :set_env => true})
+    t.add_env({:name => 'RAKE_VER',     :default => default_rake_ver,  :message => 'The rake version to use when running unit tests', :set_env => true})
+  end
+
 end
-
-task :test => [:check_test]
-
-task :generate_host_config do |t, args|
-
-  target = ENV["LAYOUT"] || ENV["TEST_TARGET"] || 'centos7-64'
-  generate = "beaker-hostgenerator"
-  generate += " #{target}"
-  generate += " > acceptance/hosts.cfg"
-  sh generate
-  sh "cat acceptance/hosts.cfg"
-end
-
-default_rake_ver = '11.0'
-
-rototiller_task :acceptance => [:generate_host_config] do |t|
-  t.add_env({:name => 'LAYOUT',   :default => 'centos7-64',
-             :message => 'The argument to pass to beaker-hostgenerator',
-             :set_env => true})
-  t.add_env({:name => 'RAKE_VER', :default => default_rake_ver,
-             :message => 'The rake version to use when running unit and acceptance tests',
-             :set_env => true})
-
-  t.add_flag do |flag|
-    flag.name = '--hosts'
-    flag.default = 'acceptance/hosts.cfg'
-    flag.message = 'The configuration file that Beaker will use'
-    flag.override_env = 'BEAKER_HOSTS'
-  end
-  t.add_flag do |flag|
-    flag.name = '--preserve-hosts'
-    flag.default = 'onfail'
-    flag.message = 'The beaker setting to preserve a provisioned host'
-    flag.override_env = 'BEAKER_PRESERVE_HOSTS'
-  end
-  t.add_flag do |flag|
-    flag.name = '--keyfile'
-    flag.default ="#{ENV['HOME']}/.ssh/id_rsa-acceptance"
-    flag.message = 'The SSH key used to access a SUT'
-    flag.override_env = 'BEAKER_KEYFILE'
-  end
-  t.add_flag do |flag|
-    flag.name = '--load-path'
-    flag.default = 'acceptance/lib'
-    flag.message = 'The load path Beaker will use'
-    flag.override_env = "BEAKER_LOAD-PATH"
-  end
-  t.add_flag do |flag|
-    flag.name = '--pre-suite'
-    flag.default = 'acceptance/pre-suite'
-    flag.message = 'THe path to a directory containing pre-suites'
-    flag.override_env = "BEAKER_PRE-SUITE"
-  end
-  t.add_flag do |flag|
-    flag.name = '--tests'
-    flag.default = 'acceptance/tests'
-    flag.message = 'The path to the tests you want beaker to run'
-    flag.override_env = 'BEAKER_TESTS'
-  end
-
-  t.add_command({:name => 'beaker --debug --no-ntp --repo-proxy --no-validate', :override_env => 'BEAKER_EXECUTABLE'})
-end
-
-rototiller_task :check_test do |t|
-  t.add_env({:name => 'SPEC_PATTERN', :default => 'spec/', :message => 'The pattern RSpec will use to find tests', :set_env => true})
-  t.add_env({:name => 'RAKE_VER',     :default => default_rake_ver,  :message => 'The rake version to use when running unit tests', :set_env => true})
-end
-
-task :yard => [:'docs:gen']
 
 namespace :docs do
   YARD_DIR = 'doc'

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,9 @@ require 'rspec/core/rake_task'
 require 'fileutils'
 require 'rototiller'
 
-task :default => :test
+task :default do
+  sh %{rake -T}
+end
 
 desc "Run spec tests"
 RSpec::Core::RakeTask.new(:test) do |t|


### PR DESCRIPTION
   (QA-3114) update our Rakefile to rototiller 1.0+

    (maint) add test namespace to Rakefile, clarify descriptions of tasks

    * remove descriptions of tasks that aren't useful to users so they don't
    show up in -T
    * add test namespace, rename spec task to test:unit
    * add acceptance task description to remove rototiller default

    (maint) describe rake tasks with -T as default task