### PR TITLE
(do not merge) (qa-3110) spike rototiller create integration suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@
 ## Making Changes
 
 * Create a topic branch from where you want to base your work.
-  * This is the `master` branch in the case of rototiller
-  * To quickly create a topic branch based on master use `git checkout -b my_contribution master`. Do not work directly on the `master` branch.
+  * This is the `master` branch for breaking changes in major version releases, the `stable` branch for non-breaking changes and bug-fixes in Y or Z releases.
+  * To quickly create a topic branch based on master use `git checkout -b my_contribution master`. Do not work directly on the `master` nor `stable` branches.
 * Make commits of logical _working_ and _functional_ units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
-* Make sure your commit messages are in the proper format.
+* Make sure your commit messages are in the proper format (a ticket ID is required in most cases).
 
         (BKR-1234) Make the example in CONTRIBUTING imperative and concrete
 
@@ -28,44 +28,30 @@
 
 * Make sure you have added [RSpec](http://rspec.info/) tests that exercise your new code.  These test should be located in the appropriate `rototiller/spec/` subdirectory.  The addition of new methods/classes or the addition of code paths to existing methods/classes requires additional RSpec coverage.
   * One should **NOT USE** the deprecated `should`/`stub` methods - **USE** `expect`/`allow`. Use of deprecated RSpec methods will result in your patch being rejected.  See a nice blog post from 2013 on [RSpec's new message expectation syntax](http://teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/).
-* Run the spec unit tests to assure nothing else was accidentally broken, using `rake test`
-  * **Bonus**: if possible ensure that `[bundle exec] rake test` runs without failures for additional Ruby versions (1.9, 2.0, etc). Rototiller supports Ruby 1.9+, and breakage of support for other rubies will cause a patch to be rejected.
-* Make sure that if you have added new functionality of sufficiently high risk, and it can not be covered adequately via unit tests (mocking, requires disk, other classes, etc), you also include acceptance tests in your PR.
+* Run the rspec unit tests to assure nothing else was accidentally broken, using `rake test`
+  * **Bonus**: if possible ensure that `[bundle exec] rake test` runs without failures for additional Ruby versions (1.9, 2.0, etc). Rototiller supports Ruby 1.9.3+, and breakage of support for other rubies will cause a patch to be rejected.
+* Make sure that if you have added new functionality of sufficiently high risk, and it can not be covered adequately via unit tests (mocking, requires disk, other classes, etc).
+  * you should also include integration or acceptance tests in your PR, where applicable
+  * integration tests are unit tests that access the filesystem, network, or fully integrate the product
+  * acceptance tests are typically end-to-end tests ensuring changes to installers, or behavior that is difficult to validate in integration.
 * Make sure that you have added documentation using [Yard](http://yardoc.org/), new methods/classes without appropriate documentation will be rejected.
   * Run the yardoc tool to ensure that your yard documentation is properly formatted and complete
   * `[bundle exec] rake docs:gen`
 * Yard docs are great for other developers, but often are difficult to read for users. If your change impacts user-facing functionality, please include changes to the human-readable markdown docs starting at README.md
-* During the time that you are working on your patch the master Rototiller branch may have changed - you'll want to [rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) before you submit your PR with `git rebase master`.  A successful rebase ensures that your patch will cleanly merge into Rototiller.
-* Submitted patches will be smoke tested through a series of acceptance level tests that ensures basic Rototiller functionality - the results of these tests will be evaluated by a Rototiller team member.  Failures associated with the submitted patch will result in the patch being rejected.
+* During the time that you are working on your patch the master Rototiller branch may have changed - you'll want to [rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) before you submit your PR with `git rebase master`.  A successful rebase ensures that your patch will cleanly merge into the project.
+* Submitted patches will be smoke tested through a series of tests that ensures code standards, code functionality and user functionality - the results of these tests will be evaluated by a team member.  Failures associated with the submitted patch will result in the patch being rejected.
 
 ## Submitting Changes
 
 * Sign the [Contributor License Agreement](http://links.puppet.com/cla).
 * Push your changes to a topic branch in _your_ fork of the repository.
-* Submit a pull request to [Rototiller](https://github.com/puppetlabs/rototiller)
+* Submit a [pull request](http://help.github.com/send-pull-requests/) to [Rototiller](https://github.com/puppetlabs/rototiller)
 * PRs are reviewed as time permits.
 
 # Additional Resources
 
 * [Rototiller's Yard Docs](http://www.rubydoc.info/github/puppetlabs/rototiller) (API/internal Architecture docs)
 * [Rototiller's Architecture](docs/rototiller_class_graph.png)
-* [More information on contributing](http://links.puppet.com/contribute-to-puppet)
-* [Contributor License Agreement](http://links.puppet.com/cla)
-* [General GitHub documentation](http://help.github.com/)
-* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
-* Questions?  Comments?  Contact the Rototiller team at qa-team@puppet.com
-  * The keyword `rototiller` is monitored and we'll get back to you as quick as we can.
-* Rototiller's Architecture: [Rototiller's Architecture](docs/rototiller_class_graph.png)
-
-## Submitting Changes
-
-* Sign the [Contributor License Agreement](http://links.puppet.com/cla).
-* Push your changes to a topic branch in _your_ fork of the repository.
-* Submit a pull request to [Rototiller](https://github.com/puppetlabs/rototiller)
-* PRs are reviewed as time permits.
-
-# Additional Resources
-
 * [More information on contributing](http://links.puppet.com/contribute-to-puppet)
 * [Contributor License Agreement](http://links.puppet.com/cla)
 * [General GitHub documentation](http://help.github.com/)

--- a/spec/integration/command_arguments_spec.rb
+++ b/spec/integration/command_arguments_spec.rb
@@ -1,0 +1,11 @@
+require_relative 'integration_helper'
+
+describe RototillerTestTask do
+  it 'can add one argument' do
+    # TODO: create helper to create randomized task names
+    # TODO: abstract this Proc.new crap
+    task_name = 'abstract_me_to_randomness'
+    block = Proc.new { |t| t.add_command({:name => 'echo', :add_argument => {:name => "#{task_name}"}}) }
+    expect{ described_class.new(task_name, &block) }.to output(task_name).to_stdout
+  end
+end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -1,0 +1,12 @@
+require 'rototiller'
+
+# tools for running a rototiller_task on localhost
+# WARNING: this WILL run tasks ON your system if you tell it to.
+class RototillerTestTask
+
+  def initialize(*args, &block)
+    task = Rototiller::Task::RototillerTask.define_task(*args, &block)
+    task.send('run_task')
+  end
+
+end


### PR DESCRIPTION

    (QA-3110) spike: rototiller create integration suite

    * implement an integration test helper set
      * this creates a helper that can run a single task in rspec
    * we could create another helper for rake -T and rake -D, etc, maybe
      * or it might make sense to just keep testing that stuff in acceptance
    * this doesn't work
      * it appears to not run the commands, not clear why


    (QA-3110) update CONTRIBUTING doc to reflect new test layout

* this part needs a bit more work on how to run units vs. integration