### PR TITLE
(SLV-454) Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+sudo: false
+bundler_args: --jobs 4 --retry 2 --without packaging documentation
+before_install:
+  - gem update --system && gem install bundler --no-document
+script:
+  - "bundle exec rake lint:rubocop"
+  - "bundle exec rspec --color"
+notifications:
+  email: false
+rvm:
+  - 2.6.2


### PR DESCRIPTION
This commit adds a .travis.yml config file to enable travis-ci to
kick off testing per PR using the `lint:rubocop` and `test:unit`
rake tasks.